### PR TITLE
partial fix for armada client changes

### DIFF
--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -12,9 +12,9 @@ source scripts/init.sh
 mvn --batch-mode clean package dependency:copy-dependencies
 dependencies=(
     target/armada-cluster-manager_${SCALA_BIN_VERSION}-1.0.0-SNAPSHOT.jar
-    target/dependency/lenses_${SCALA_BIN_VERSION}-0.11.13.jar
-    target/dependency/scalapb-runtime_${SCALA_BIN_VERSION}-0.11.13.jar
-    target/dependency/scalapb-runtime-grpc_${SCALA_BIN_VERSION}-0.11.13.jar
+    target/dependency/lenses_${SCALA_BIN_VERSION}-0.9.8.jar
+    target/dependency/scalapb-runtime_${SCALA_BIN_VERSION}-0.9.8.jar
+    target/dependency/scalapb-runtime-grpc_${SCALA_BIN_VERSION}-0.9.8.jar
     target/dependency/armada-scala-client_${SCALA_BIN_VERSION}-0.1.0-SNAPSHOT.jar
 )
 
@@ -55,6 +55,12 @@ if [ -e  $SPARK_HOME/assembly/target/scala-${SCALA_BIN_VERSION}/jars/protobuf-ja
     # will be replaced with: protobuf-java-3.19.6.jar
     rm $SPARK_HOME/assembly/target/scala-${SCALA_BIN_VERSION}/jars/protobuf-java-2.5.0.jar
 fi
+
+# Remove no longer used jars
+rm -f $SPARK_HOME/assembly/target/scala-${SCALA_BIN_VERSION}/jars/lenses_${SCALA_BIN_VERSION}-0.11.13.jar
+rm -f $SPARK_HOME/assembly/target/scala-${SCALA_BIN_VERSION}/jars/scalapb-runtime_${SCALA_BIN_VERSION}-0.11.13.jar
+rm -f $SPARK_HOME/assembly/target/scala-${SCALA_BIN_VERSION}/jars/scalapb-runtime-grpc_${SCALA_BIN_VERSION}-0.11.13.jar
+
 
 
 # Copy dependencies to the docker image directory


### PR DESCRIPTION
When the spark client moved back the scalapb version from 0.11.13 to 0.9.8, it broke the apache-spark docker file builder, scripts/createImage.sh

A partial fix is included in this PR.

That seems to fix the spark 3.3 and 4.1 versions.

The spark 3.5 version fails in the driver with this error, which I'm still investigating:

```
25/03/18 03:00:44 INFO SparkContext: Successfully stopped SparkContext
Exception in thread "main" io.grpc.StatusRuntimeException: CANCELLED: Failed to read message.
	at io.grpc.stub.ClientCalls.toStatusRuntimeException(ClientCalls.java:271)
	at io.grpc.stub.ClientCalls.getUnchecked(ClientCalls.java:252)
	at io.grpc.stub.ClientCalls.blockingUnaryCall(ClientCalls.java:131)
	at scalapb.grpc.ClientCalls$.blockingUnaryCall(ClientCalls.scala:15)
	at api.submit.SubmitGrpc$SubmitBlockingStub.submitJobs(SubmitGrpc.scala:194)
	at io.armadaproject.armada.ArmadaClient.submitJobs(ArmadaClient.scala:30)
	at org.apache.spark.scheduler.cluster.armada.ArmadaClusterSchedulerBackend.submitJob(ArmadaClusterManagerBackend.scala:115)
	at org.apache.spark.scheduler.cluster.armada.ArmadaClusterSchedulerBackend.$anonfun$start$1(ArmadaClusterManagerBackend.scala:125)
	at scala.collection.immutable.Range.foreach$mVc$sp(Range.scala:158)
	at org.apache.spark.scheduler.cluster.armada.ArmadaClusterSchedulerBackend.start(ArmadaClusterManagerBackend.scala:125)
	at org.apache.spark.scheduler.TaskSchedulerImpl.start(TaskSchedulerImpl.scala:235)
	at org.apache.spark.SparkContext.<init>(SparkContext.scala:599)
	at org.apache.spark.SparkContext$.getOrCreate(SparkContext.scala:2883)
	at org.apache.spark.sql.SparkSession$Builder.$anonfun$getOrCreate$2(SparkSession.scala:1099)
	at scala.Option.getOrElse(Option.scala:189)
	at org.apache.spark.sql.SparkSession$Builder.getOrCreate(SparkSession.scala:1093)
	at org.apache.spark.examples.SparkPi$.main(SparkPi.scala:30)
	at org.apache.spark.examples.SparkPi.main(SparkPi.scala)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:1029)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:194)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:217)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:91)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1120)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1129)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
Caused by: java.lang.NoSuchMethodError: 'scalapb.GeneratedMessage scalapb.GeneratedMessageCompanion.parseFrom$(scalapb.GeneratedMessageCompanion, com.google.protobuf.CodedInputStream)'
	at api.submit.JobSubmitResponse$.parseFrom(JobSubmitResponse.scala:75)
	at scalapb.GeneratedMessageCompanion.parseFrom(GeneratedMessageCompanion.scala:171)
	at scalapb.GeneratedMessageCompanion.parseFrom$(GeneratedMessageCompanion.scala:171)
	at api.submit.JobSubmitResponse$.parseFrom(JobSubmitResponse.scala:75)
	at scalapb.grpc.Marshaller.parse(Marshaller.scala:12)
	at scalapb.grpc.Marshaller.parse(Marshaller.scala:7)
	at io.grpc.MethodDescriptor.parseResponse(MethodDescriptor.java:284)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:661)
	at io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:646)
	at io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
	at io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:840)
```
