### PR TITLE
Fix build issue by aligning Scala version with Spark pom.xml

### DIFF
--- a/.github/workflows/build-snapshots.yaml
+++ b/.github/workflows/build-snapshots.yaml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - scala_version: "2.13.8"
+          - scala_version: "2.13.16"
             spark_version: "4.1.0-SNAPSHOT"
 
     steps:


### PR DESCRIPTION
Scala versions should be aligned between Armada-Spark and Spark to avoid compile errors like these:
```
Error:  Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.9.2:compile (default) on project armada-cluster-manager_2.13: wrap: scala.reflect.internal.FatalError: 
Error:    bad constant pool index: 0 at pos: 1449
Error:       while compiling: /home/runner/work/armada-spark/armada-spark/src/main/scala-spark-4.1/org/apache/spark/deploy/SparkSubmit.scala
Error:          during phase: globalPhase=xsbt-api, enteringPhase=parser
Error:       library version: version 2.13.8
Error:      compiler version: version 2.13.8
Error:    reconstructed args: -bootclasspath ...
Error:  
Error:    last tree to typer: This(class ArmadaClusterSchedulerBackend)
Error:         tree position: line 46 of /home/runner/work/armada-spark/armada-spark/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
Error:              tree tpe: ArmadaClusterSchedulerBackend.this.type
Error:                symbol: (private[package spark]) class ArmadaClusterSchedulerBackend in package armada
Error:     symbol definition: private[package spark] class ArmadaClusterSchedulerBackend extends CoarseGrainedSchedulerBackend (a ClassSymbol)
Error:        symbol package: org.apache.spark.scheduler.cluster.armada
Error:         symbol owners: class ArmadaClusterSchedulerBackend
Error:             call site: class ArmadaClusterSchedulerBackend in package armada in package armada
Error:  
Error:  == Source file context for tree position ==
Error:  
Error:      43   private val appId = "fake_app_id_FIXME"
Error:      44 
Error:      45   private val initialExecutors = SchedulerBackendUtils.getInitialTargetExecutorNumber(conf)
Error:      46   private val executorTracker = new ExecutorTracker(new SystemClock(), initialExecutors)
Error:      47 
Error:      48 
Error:      49   override def applicationId(): String = {
Error:  -> [Help 1]
Error:  
Error:  To see the full stack trace of the errors, re-run Maven with the -e switch.
Error:  Re-run Maven using the -X switch to enable full debug logging.
Error:  
Error:  For more information about the errors and possible solutions, please read the following articles:
Error:  [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
Error: Process completed with exit code 1.
```