### PR TITLE
Add Node Selector Support

### DIFF
--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -43,3 +43,6 @@ docker build \
   --build-arg scala_binary_version=$SCALA_BIN_VERSION \
   -f "$root/docker/Dockerfile" \
   "$root"
+
+# Load on armada test cluster
+kind load docker-image spark:armada-testing --name armada-test

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -43,6 +43,3 @@ docker build \
   --build-arg scala_binary_version=$SCALA_BIN_VERSION \
   -f "$root/docker/Dockerfile" \
   "$root"
-
-# Load on armada test cluster
-kind load docker-image spark:armada-testing --name armada-test

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -57,7 +57,7 @@ private[spark] object Config {
 
   // See https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
   // Clients do not use the prefix, therefore we just accept the name portion on label selector names.
-  private val label = "([a-z0-9A-z&&[^-_.]]([a-z0-9A-Z-_.]{0,61}[a-z0-9A-Z&&[^-_.]])?)"
+  private val label = "([\\w&&[^-_.]]([\\w-_.]{0,61}[\\w&&[^-_.]])?)"
   private val labelSelectors: Regex = (s"^($label=$label(,$label=$label)*)?$$").r
 
   private[armada] val selectorsValidator = selectors => labelSelectors.matches(selectors)

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -69,10 +69,15 @@ private[spark] object Config {
   }
 
   def transformSelectorsToMap(str: String): Map[String,String] = {
-    str.split(",").map(a => a.split("=")(0) -> a.split("=")(1)).toMap
+    if (str.trim.isEmpty) {
+      Map()
+    }
+    else {
+      str.split(",").map(a => a.split("=")(0) -> a.split("=")(1)).toMap
+    }
   }
 
-  val DEFAULT_CLUSTER_SELECTORS = "armada-spark=true,armada-cluster-name=spark-cluster-001"
+  val DEFAULT_CLUSTER_SELECTORS = ""
 
   val ARMADA_CLUSTER_SELECTORS: ConfigEntry[String] =
     ConfigBuilder("spark.armada.clusterSelectors")

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -60,7 +60,7 @@ private[spark] object Config {
   private val label = "([\\w&&[^-_.]]([\\w-_.]{0,61}[\\w&&[^-_.]])?)"
   private val labelSelectors: Regex = (s"^($label=$label(,$label=$label)*)?$$").r
 
-  private[armada] val selectorsValidator = selectors => labelSelectors.matches(selectors)
+  private[armada] val selectorsValidator: CharSequence => Boolean = selectors => labelSelectors.matches(selectors)
 
   def transformSelectorsToMap(str: String): Map[String,String] = {
     str.split(",").map(a => a.split("=")(0) -> a.split("=")(1)).toMap

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -60,7 +60,13 @@ private[spark] object Config {
   private val label = "([\\w&&[^-_.]]([\\w-_.]{0,61}[\\w&&[^-_.]])?)"
   private val labelSelectors: Regex = (s"^($label=$label(,$label=$label)*)?$$").r
 
-  private[armada] val selectorsValidator: CharSequence => Boolean = selectors => labelSelectors.matches(selectors)
+  private[armada] val selectorsValidator: CharSequence => Boolean = selectors => {
+    val selectorsMaybe = labelSelectors.findPrefixMatchOf(selectors)
+    selectorsMaybe match {
+      case Some(selectors) => true
+      case None => false
+    }
+  }
 
   def transformSelectorsToMap(str: String): Map[String,String] = {
     str.split(",").map(a => a.split("=")(0) -> a.split("=")(1)).toMap

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -66,13 +66,13 @@ private[spark] object Config {
     str.split(",").map(a => a.split("=")(0) -> a.split("=")(1)).toMap
   }
 
+  val DEFAULT_CLUSTER_SELECTORS = "armada-spark=true,armada-cluster-name=spark-cluster-001"
+
   val ARMADA_CLUSTER_SELECTORS: ConfigEntry[String] =
     ConfigBuilder("spark.armada.clusterSelectors")
       .doc("A comma separated list of kubernetes label selectors (in key=value format) to ensure " +
            "the spark driver and its executors are deployed to the same cluster.")
       .stringConf
       .checkValue(selectorsValidator, "Selectors must be valid kubernetes labels/selectors")
-      .createWithDefaultString("armada-spark=true,armada-cluster-name=spark-cluster-001")
+      .createWithDefaultString(DEFAULT_CLUSTER_SELECTORS)
 }
-
-

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -36,8 +36,8 @@ import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkApplication
-import org.apache.spark.deploy.armada.Config.{DEFAULT_CLUSTER_SELECTORS, ARMADA_CLUSTER_SELECTORS,
-  ARMADA_LOOKOUTURL, transformSelectorsToMap}
+import org.apache.spark.deploy.armada.Config.{ARMADA_CLUSTER_SELECTORS,
+  ARMADA_HEALTH_CHECK_TIMEOUT, ARMADA_LOOKOUTURL, DEFAULT_CLUSTER_SELECTORS, transformSelectorsToMap}
 
 /* import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -370,7 +370,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       .withRestartPolicy("Never")
       .withContainers(Seq(driverContainer))
       .withVolumes(configGenerator.getVolumes)
-      .withNodeSelector(transformSelectorsToMap(DEFAULT_CLUSTER_SELECTORS))
+      .withNodeSelector(transformSelectorsToMap(conf.get(ARMADA_CLUSTER_SELECTORS)))
 
     val driverJob = api.submit
       .JobSubmitRequestItem()

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -36,7 +36,8 @@ import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkApplication
-import org.apache.spark.deploy.armada.Config.{ARMADA_CLUSTER_SELECTORS, ARMADA_LOOKOUTURL, transformSelectorsToMap}
+import org.apache.spark.deploy.armada.Config.{DEFAULT_CLUSTER_SELECTORS, ARMADA_CLUSTER_SELECTORS,
+  ARMADA_LOOKOUTURL, transformSelectorsToMap}
 
 /* import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
@@ -347,7 +348,6 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
           "spark.driver.port=7078",
           "--conf",
           "spark.driver.host=$(SPARK_DRIVER_BIND_ADDRESS)"
-
         ) ++ confSeq ++ primaryResource ++ clientArguments.driverArgs
       )
       .withResources( // FIXME: What are reasonable requests/limits for spark drivers?
@@ -370,7 +370,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       .withRestartPolicy("Never")
       .withContainers(Seq(driverContainer))
       .withVolumes(configGenerator.getVolumes)
-      .withNodeSelector(transformSelectorsToMap(conf.get("spark.armada.clusterSelectors")))
+      .withNodeSelector(transformSelectorsToMap(DEFAULT_CLUSTER_SELECTORS))
 
     val driverJob = api.submit
       .JobSubmitRequestItem()

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -36,7 +36,7 @@ import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkApplication
-import org.apache.spark.deploy.armada.Config._
+import org.apache.spark.deploy.armada.Config.{ARMADA_CLUSTER_SELECTORS, ARMADA_LOOKOUTURL, transformSelectorsToMap}
 
 /* import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -36,7 +36,7 @@ import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.SparkApplication
-import org.apache.spark.deploy.armada.Config.{ARMADA_HEALTH_CHECK_TIMEOUT, ARMADA_LOOKOUTURL}
+import org.apache.spark.deploy.armada.Config._
 
 /* import org.apache.spark.deploy.k8s._
 import org.apache.spark.deploy.k8s.Config._
@@ -370,6 +370,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       .withRestartPolicy("Never")
       .withContainers(Seq(driverContainer))
       .withVolumes(configGenerator.getVolumes)
+      .withNodeSelector(transformSelectorsToMap(conf.get("spark.armada.clusterSelectors")))
 
     val driverJob = api.submit
       .JobSubmitRequestItem()

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -20,7 +20,8 @@ import io.armadaproject.armada.ArmadaClient
 import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkContext
-import org.apache.spark.deploy.armada.Config._
+import org.apache.spark.deploy.armada.Config.{ARMADA_CLUSTER_SELECTORS, 
+  ARMADA_EXECUTOR_TRACKER_POLLING_INTERVAL, ARMADA_EXECUTOR_TRACKER_TIMEOUT, transformSelectorsToMap}
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
 import org.apache.spark.scheduler.{ExecutorDecommission, TaskSchedulerImpl}

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -123,7 +123,7 @@ private[spark] class ArmadaClusterSchedulerBackend(
       .withTerminationGracePeriodSeconds(0)
       .withRestartPolicy("Never")
       .withContainers(Seq(executorContainer))
-      .withNodeSelector(transformSelectorsToMap(conf.get("spark.armada.clusterSelectors")))
+      .withNodeSelector(transformSelectorsToMap(conf.get(ARMADA_CLUSTER_SELECTORS)))
 
     val testJob = api.submit
       .JobSubmitRequestItem()

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -20,7 +20,7 @@ import io.armadaproject.armada.ArmadaClient
 import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkContext
-import org.apache.spark.deploy.armada.Config.{ARMADA_EXECUTOR_TRACKER_POLLING_INTERVAL, ARMADA_EXECUTOR_TRACKER_TIMEOUT}
+import org.apache.spark.deploy.armada.Config._
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
 import org.apache.spark.scheduler.{ExecutorDecommission, TaskSchedulerImpl}
@@ -117,10 +117,12 @@ private[spark] class ArmadaClusterSchedulerBackend(
         )
       )
 
+
     val podSpec = PodSpec()
       .withTerminationGracePeriodSeconds(0)
       .withRestartPolicy("Never")
       .withContainers(Seq(executorContainer))
+      .withNodeSelector(transformSelectorsToMap(conf.get("spark.armada.clusterSelectors")))
 
     val testJob = api.submit
       .JobSubmitRequestItem()

--- a/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.deploy.armada
 
 
+import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import Config._
 
@@ -56,5 +57,10 @@ class ConfigSuite
         val result = Config.selectorsValidator(tc.testSelectors)
         assert(result == tc.expectedValid, s"test name: '${tc.name}', test value: '${tc.testSelectors}'")
     }
+  }
+
+  test("defaultClusterSelectors") {
+    val conf = new SparkConf(true)
+    assert(conf.get(ARMADA_CLUSTER_SELECTORS) == DEFAULT_CLUSTER_SELECTORS)
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
@@ -33,6 +33,7 @@ class ConfigSuite
     val testCases = List[TestCase](
       // Valid cases
       TestCase("", true, "empty case"),
+      TestCase("a=1", true, "One character long name and value"),
       TestCase("armada-spark=true", true, "One valid selector"),
       TestCase("armada-spark=true,spark-cluster-name=001", true, "Two valid selectors"),
       TestCase("armada-spark=false,name=spark-cluster-001,a=1,b=2,c=3", true, "Several valid selectors"),

--- a/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
@@ -32,16 +32,24 @@ class ConfigSuite
     val testCases = List[TestCase](
       // Valid cases
       TestCase("", true, "empty case"),
-      TestCase("armada-spark", true, "One valid selector"),
-      TestCase("armada-spark,spark-cluster-001", true, "Two valid selectors"),
-      TestCase("armada-spark,spark-cluster-001,a,b,c", true, "Several valid selectors"),
-      TestCase("a" * 63, true, "Selector length limit of 63"),
-      TestCase("a" * 30 + "-._" + "b" * 30, true, "Selector length limit of 63 with valid non-alphanumeric chars"),
+      TestCase("armada-spark=true", true, "One valid selector"),
+      TestCase("armada-spark=true,spark-cluster-name=001", true, "Two valid selectors"),
+      TestCase("armada-spark=false,name=spark-cluster-001,a=1,b=2,c=3", true, "Several valid selectors"),
+      TestCase("a" * 63 + "=" + "b" * 63, true, "Selector name & value length limit of 63"),
+      TestCase("a" * 30 + "-._" + "b" * 30 + "=b", true,
+        "Selector name length limit of 63 with valid non-alphanumeric chars"),
       // Invalid cases
-      TestCase("_armada", false, "Selector must start with an alphanumeric character."), 
-      TestCase("armada_", false, "Selector must end with an alphanumeric character."),
-      TestCase("#@armada-spark,spark-cluster-001", false, "Illegal characters: # @"),
-      TestCase("a" * 64, false, "Selectors must be 63 characters or less"),
+      TestCase("a", false, "key but no value"),
+      TestCase("a=", false, "key & = but no value"),
+      TestCase("=b", false, "value & = but no key"),
+      TestCase("=", false, "just = and no key or value"),
+      TestCase("_armada=a", false, "Selector labels must start with an alphanumeric character."),
+      TestCase("armada_=b", false, "Selector labels must end with an alphanumeric character."),
+      TestCase("armada=_armada", false, "Selector values must start with an alphanumeric character."),
+      TestCase("armada=armada_", false, "Selector values must end with an alphanumeric character."),
+      TestCase("#@armada-spark=true,spark-cluster-name=spark-cluster-001", false, "Illegal characters: # @"),
+      TestCase("a" * 64 + "=b", false, "Selector names must be 63 characters or less"),
+      TestCase("armada=" + ("b" * 64), false, "Selector values must be 63 characters or less"),
     )
 
     for (tc <- testCases) {

--- a/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.deploy.armada
+
+
+import org.scalatest.funsuite.AnyFunSuite
+import Config._
+
+class ConfigSuite
+ extends AnyFunSuite {
+  test("testClusterSelectorsValidator") {
+    case class TestCase(
+      testSelectors: String,
+      expectedValid: Boolean,
+      name: String)
+
+    val testCases = List[TestCase](
+      // Valid cases
+      TestCase("", true, "empty case"),
+      TestCase("armada-spark", true, "One valid selector"),
+      TestCase("armada-spark,spark-cluster-001", true, "Two valid selectors"),
+      TestCase("armada-spark,spark-cluster-001,a,b,c", true, "Several valid selectors"),
+      TestCase("a" * 63, true, "Selector length limit of 63"),
+      TestCase("a" * 30 + "-._" + "b" * 30, true, "Selector length limit of 63 with valid non-alphanumeric chars"),
+      // Invalid cases
+      TestCase("_armada", false, "Selector must start with an alphanumeric character."), 
+      TestCase("armada_", false, "Selector must end with an alphanumeric character."),
+      TestCase("#@armada-spark,spark-cluster-001", false, "Illegal characters: # @"),
+      TestCase("a" * 64, false, "Selectors must be 63 characters or less"),
+    )
+
+    for (tc <- testCases) {
+        val result = Config.selectorsValidator(tc.testSelectors)
+        assert(result == tc.expectedValid, s"test name: '${tc.name}', test value: '${tc.testSelectors}'")
+    }
+  }
+}


### PR DESCRIPTION
This adds node selector support in order to ensure drivers and executors are scheduled to the same kubernetes cluster within armada.

I've tested partially locally in the case where armada will not schedule due to node selectors: 

> Cluster1:
Node:                       none
Number of nodes in cluster: 2
Excluded nodes:
 1: taint node-role.kubernetes.io/control-plane=:NoSchedule not tolerated
 1: node does not match pod NodeSelector: label armada-spark not set

I've further verified the selectors are present in the job yaml:
```yaml
        nodeSelector:
          armada-cluster-name: spark-cluster-001
          armada-spark: 'true'
```
But still need to configure local armada for multi-cluster operation.
