### PR TITLE
feat: add support for providing labels to driver and executor

### DIFF
--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -22,7 +22,7 @@ import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkContext
 import org.apache.spark.deploy.armada.Config.{ARMADA_CLUSTER_SELECTORS,
   ARMADA_EXECUTOR_TRACKER_POLLING_INTERVAL, ARMADA_EXECUTOR_TRACKER_TIMEOUT,
-  transformSelectorsToMap, GANG_SCHEDULING_NODE_UNIFORMITY_LABEL}
+  commaSeparatedLabelsToMap, GANG_SCHEDULING_NODE_UNIFORMITY_LABEL}
 import org.apache.spark.deploy.armada.submit.GangSchedulingAnnotations._
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}


### PR DESCRIPTION
Add the following config fields:
* `spark.armada.global.labels` - define labels for both driver and executor pods
* `spark.armada.driver.labels` - define labels for driver pod
* `spark.armada.executor.labels` - define labels for executor pods

Add support for proper DNS-1123 labels