### PR TITLE
feat: add lint step in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,6 +14,9 @@ on:
 permissions: {}
 
 jobs:
+  lint:
+    name: Lint
+    uses: ./.github/workflows/lint.yaml
   build:
     name: Build
     uses: ./.github/workflows/build.yaml

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,0 +1,31 @@
+name: Lint
+
+on:
+  workflow_call:
+
+permissions: {}
+
+jobs:
+  scala-lint:
+    name: Lint Scala code
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: '17'
+
+      - name: Cache Maven local repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-spotless-check-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-spotless-check
+
+      - name: Run lint check
+        run: mvn -B spotless:check


### PR DESCRIPTION
Add a CI job which runs code lint (`mvn spotless:check`).

This PR depends on https://github.com/armadaproject/armada-spark/pull/38