### PR TITLE
chore: refactor validation logic around submission

### DIFF
--- a/scripts/submitSparkPi.sh
+++ b/scripts/submitSparkPi.sh
@@ -39,5 +39,5 @@ docker run --rm --network host $IMAGE_NAME \
     --conf spark.executor.instances=4 \
     --conf spark.kubernetes.container.image=$IMAGE_NAME \
     --conf spark.armada.lookouturl=$ARMADA_LOOKOUT_URL \
-    --conf spark.armada.clusterSelectors="armada-spark=true" \
+    --conf spark.armada.scheduling.nodeSelectors="armada-spark=true" \
     $FIRST_ARG 100

--- a/src/main/scala/org/apache/spark/deploy/armada/validators/K8sValidator.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/validators/K8sValidator.scala
@@ -1,0 +1,163 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.spark.deploy.armada.validators
+
+import java.util.regex.Pattern
+
+/** Abstract parent for anything that needs to validate a k8s-style key.
+  *
+  * @param namePattern
+  *   regex that the NAME segment must match
+  */
+abstract class K8sValidator(protected val namePattern: Pattern) {
+  import K8sValidator._
+
+  /** Validates that a key conforms to [<DNS-1123 subdomain>/]NAME syntax.
+    *
+    *   - Optional prefix: DNS-1123 subdomain (≤ maxPrefixLength chars)
+    *   - Required NAME segment: ≤ maxNameLength chars, matching namePattern
+    *
+    * @param key
+    *   the full key to validate
+    * @return
+    *   true if valid; false otherwise
+    */
+  def isValidKey(key: String): Boolean = {
+    if (key == null) return false
+
+    // split into optional prefix and required name
+    val (prefixOpt, name) =
+      if (key.contains("/")) {
+        val Array(pref, nm) = key.split("/", 2)
+        (Some(pref), nm)
+      } else (None, key)
+
+    // name non-empty, length ≤ 63, matches the provided NAME regex
+    if (name.isEmpty || name.length > maxNameLength) return false
+    if (!namePattern.matcher(name).matches()) return false
+
+    // prefix (if present) ≤ 253 chars and must be a DNS-1123 subdomain
+    prefixOpt.forall { pref =>
+      pref.length <= maxPrefixLength &&
+      subdomainPattern.matcher(pref).matches()
+    }
+  }
+
+  /** Validates the value associated with the key.
+    *
+    * @param value
+    *   the string value to validate
+    * @return
+    *   true if valid; false otherwise
+    */
+  def isValidValue(value: String): Boolean
+}
+
+object K8sValidator {
+  // Maximum lengths per Kubernetes docs
+  private val maxNameLength   = 63  // for NAME segments
+  private val maxPrefixLength = 253 // for DNS-1123 subdomain prefixes
+
+  // DNS-1123 label (lowercase) and subdomain regex
+  private val dns1123Label = "[a-z0-9]([a-z0-9\\-]*[a-z0-9])?"
+  // DNS-1123 subdomain: series of labels separated by '.', total ≤253 chars
+  private val subdomainFragment = s"$dns1123Label(?:\\.$dns1123Label)*"
+  private val subdomainPattern  = Pattern.compile(s"^$subdomainFragment$$")
+
+  // shared NAME regex: 1–63 chars, begin/end alnum [A-Za-z0-9], interior [-_.A-Za-z0-9]
+  private val nameFragment = "[A-Za-z0-9]([A-Za-z0-9_.-]*[A-Za-z0-9])?"
+  private val namePattern  = Pattern.compile(s"^$nameFragment$$")
+
+  /** Concrete validator for Kubernetes labels.
+    *
+    * Label values must be empty or ≤63 chars matching the NAME syntax.
+    */
+  object Label extends K8sValidator(namePattern) {
+    override def isValidValue(value: String): Boolean = {
+      if (value == null) false
+      else if (value.isEmpty) true
+      else
+        value.length <= maxNameLength &&
+        namePattern.matcher(value).matches()
+    }
+  }
+
+  /** Concrete validator for Kubernetes annotations.
+    *
+    * Annotation values can be any UTF-8 string up to 256 KiB.
+    */
+  object Annotation extends K8sValidator(namePattern) {
+    private val maxBytes = 256 * 1024
+
+    /** Validates an annotation value.
+      *
+      * @param value
+      *   the annotation's value to validate
+      * @return
+      *   true if non-null and UTF-8 byte length ≤ maxBytes; false otherwise
+      */
+    override def isValidValue(value: String): Boolean = {
+      value != null && value.getBytes("UTF-8").length <= maxBytes
+    }
+  }
+
+  /** Validator for metadata.name (a DNS-1123 subdomain).
+    *
+    * Must consist of lower-case alphanumeric characters, '-' or '.', start and end with an
+    * alphanumeric character, and be ≤253 chars.
+    */
+  object Name {
+
+    /** Validates a fully-specified metadata.name.
+      *
+      * Uses the same DNS-1123 subdomain rules as prefixes.
+      *
+      * @param name
+      *   the metadata.name to validate
+      * @return
+      *   true if non-null, non-empty, ≤ maxPrefixLength, and matches subdomainPattern
+      */
+    def isValid(name: String): Boolean = {
+      if (name == null) return false
+      // non-empty, max total length 253
+      if (name.isEmpty || name.length > maxPrefixLength) return false
+      // match the DNS-1123 subdomain pattern
+      subdomainPattern.matcher(name).matches()
+    }
+
+    /** Validates a generateName prefix.
+      *
+      *   - non-null, non-empty
+      *   - length ≤ 30 characters
+      *   - may contain uppercase/lowercase letters, digits, hyphens, underscores, or dots
+      *   - may start or end with a hyphen or dot
+      *
+      * @param prefix
+      *   the generateName prefix to validate
+      * @return
+      *   true if valid; false otherwise
+      */
+    def isValidPrefix(prefix: String): Boolean = {
+      if (prefix == null) return false
+      val length = prefix.length
+      if (length == 0 || length > 30) return false
+      prefixPattern.matcher(prefix).matches()
+    }
+    // Pattern for generateName prefixes: allows any alphanumeric (any case), '-', or '.', up to 30 chars
+    private val prefixPattern = Pattern.compile("^[A-Za-z0-9.-]+$")
+  }
+}

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -21,11 +21,11 @@ import k8s.io.api.core.v1.generated._
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.apache.spark.SparkContext
 import org.apache.spark.deploy.armada.Config.{
-  ARMADA_CLUSTER_SELECTORS,
+  ARMADA_JOB_NODE_SELECTORS,
   ARMADA_EXECUTOR_TRACKER_POLLING_INTERVAL,
   ARMADA_EXECUTOR_TRACKER_TIMEOUT,
   commaSeparatedLabelsToMap,
-  GANG_SCHEDULING_NODE_UNIFORMITY_LABEL
+  ARMADA_JOB_GANG_SCHEDULING_NODE_UNIFORMITY
 }
 import org.apache.spark.deploy.armada.submit.GangSchedulingAnnotations
 import org.apache.spark.rpc.{RpcAddress, RpcCallContext}
@@ -54,7 +54,7 @@ private[spark] class ArmadaClusterManagerBackend(
     GangSchedulingAnnotations(
       None,
       initialExecutors,
-      conf.get(GANG_SCHEDULING_NODE_UNIFORMITY_LABEL)
+      conf.get(ARMADA_JOB_GANG_SCHEDULING_NODE_UNIFORMITY)
     )
 
   override def applicationId(): String = {

--- a/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/ConfigSuite.scala
@@ -20,65 +20,13 @@ package org.apache.spark.deploy.armada
 import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import Config._
-import org.apache.spark.deploy.armada.K8sLabelValidator.{isValidKey, isValidValue}
 import org.scalatest.prop.TableDrivenPropertyChecks
 import org.scalatest.matchers.should.Matchers
 
 class ConfigSuite extends AnyFunSuite with TableDrivenPropertyChecks with Matchers {
-  test("testClusterSelectorsValidator") {
-    val testCases = Table( // columns
-      ("testSelectors", " expectedValid", " name"),
-      // rows
-      // Valid cases
-      ("", true, "empty case"),
-      ("a=1", true, "One character long name and value"),
-      ("armada-spark=true", true, "One valid selector"),
-      ("armada-spark=true,spark-cluster-name=001", true, "Two valid selectors"),
-      (
-        "armada-spark=false,name=spark-cluster-001,a=1,b=2,c=3",
-        true,
-        "Several valid selectors"
-      ),
-      ("a" * 63 + "=" + "b" * 63, true, "Selector name & value length limit of 63"),
-      (
-        "a" * 30 + "-._" + "b" * 30 + "=b",
-        true,
-        "Selector name length limit of 63 with valid non-alphanumeric chars"
-      ),
-      // Invalid cases
-      ("a", false, "key but no value"),
-      ("a=", false, "key & = but no value"),
-      ("=b", false, "value & = but no key"),
-      ("=", false, "just = and no key or value"),
-      ("_armada=a", false, "Selector labels must start with an alphanumeric character."),
-      ("armada_=b", false, "Selector labels must end with an alphanumeric character."),
-      (
-        "armada=_armada",
-        false,
-        "Selector values must start with an alphanumeric character."
-      ),
-      ("armada=armada_", false, "Selector values must end with an alphanumeric character."),
-      (
-        "#@armada-spark=true,spark-cluster-name=spark-cluster-001",
-        false,
-        "Illegal characters: # @"
-      ),
-      ("armada-spark=false,a==2", false, "Double equal sign"),
-      ("armada-spark=false,a=b=2", false, "Two equal signs in label"),
-      ("a" * 64 + "=b", false, "Selector names must be 63 characters or less"),
-      ("armada=" + ("b" * 64), false, "Selector values must be 63 characters or less")
-    )
-
-    forAll(testCases) { (testSelectors, expectedValid, name) =>
-      withClue(name) {
-        assert(Config.selectorsValidator(testSelectors) == expectedValid)
-      }
-    }
-  }
-
   test("defaultClusterSelectors") {
     val conf = new SparkConf(true)
-    assert(conf.get(ARMADA_CLUSTER_SELECTORS) == DEFAULT_CLUSTER_SELECTORS)
+    assert(conf.get(ARMADA_JOB_NODE_SELECTORS) == "")
   }
 
   test("commaSeparatedLabelsToMap") {
@@ -96,51 +44,6 @@ class ConfigSuite extends AnyFunSuite with TableDrivenPropertyChecks with Matche
 
     forAll(testCases) { (labels, expected) =>
       commaSeparatedLabelsToMap(labels) shouldEqual expected
-    }
-  }
-
-  test("K8sLabelValidator.isValidKey") {
-    val cases = Table(
-      ("key", "valid"),
-      ("", false),
-      ("app", true),
-      ("my-domain.io/app", true),
-      ("example.com/label-name", true),
-      ("example_1.com/label-name", true),
-      ("a.b/a.s", true),
-      ("a" * 254 + "/label-name", false),
-      ("_invalid", false),
-      ("invalid-", false),
-      ("/no-prefix-name", false),
-      ("toolong" * 50, false),
-      (null.asInstanceOf[String], false)
-    )
-
-    forAll(cases) { (key, valid) =>
-      withClue(s"isValidKey('$key'): ") {
-        isValidKey(key) shouldBe valid
-      }
-    }
-  }
-
-  test("K8sLabelValidator.isValidValue") {
-    val cases = Table(
-      ("value", "valid"),
-      ("", true),
-      ("frontend", true),
-      ("a", true),
-      ("invalid value", false),
-      ("-leading", false),
-      ("trailing-", false),
-      ("a" * 63, true),
-      ("a" * 64, false),
-      (null.asInstanceOf[String], false)
-    )
-
-    forAll(cases) { (value, valid) =>
-      withClue(s"isValidValue('$value'): ") {
-        isValidValue(value) shouldBe valid
-      }
     }
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/armada/validators/K8sValidatorSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/validators/K8sValidatorSuite.scala
@@ -1,0 +1,124 @@
+package org.apache.spark.deploy.armada.validators
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks._
+
+class K8sValidatorSuite extends AnyFunSuite with Matchers {
+  test(
+    "label and annotation name - isValidKey should accept valid annotation keys and reject invalid ones"
+  ) {
+    val keyTests = Table(
+      ("key", "expected"),
+      ("description", true),
+      ("example.com/description", true),
+      ("valid-prefix/name_1", true),
+      ("foo.bar/baz", true),
+      ("invalid_prefix/name", false),
+      ("invalid key", false),
+      ("", false),
+      ("/leadingSlash", false),
+      ("trailingSlash/", false),
+      ("a" * 254 + "/foo", false)
+    )
+
+    forAll(keyTests) { (key: String, expected: Boolean) =>
+      K8sValidator.Annotation.isValidKey(key) shouldBe expected
+    }
+  }
+
+  test(
+    "annotation - isValidValue should accept values under size limit and reject oversized ones"
+  ) {
+    val small = "x" * 500
+    val big   = "x" * (256 * 1024 + 1)
+
+    val valueTests = Table(
+      ("value", "expected"),
+      ("", true),
+      ("some:value", true),
+      (small, true),
+      (big, false)
+    )
+
+    forAll(valueTests) { (value: String, expected: Boolean) =>
+      K8sValidator.Annotation.isValidValue(value) shouldBe expected
+    }
+  }
+
+  test("label - isValidValue should accept valid values and reject invalid ones") {
+    val valueTests = Table(
+      ("value", "expected"),
+      ("", true),
+      ("my-app", true),
+      ("App1", true),
+      ("-wrong", false),
+      ("a" * 64, false),
+      ("invalid/value", false)
+    )
+
+    forAll(valueTests) { (value: String, expected: Boolean) =>
+      K8sValidator.Label.isValidValue(value) shouldBe expected
+    }
+  }
+
+  test("name - isValid should accept valid DNS-1123 subdomain names and reject invalid ones") {
+    // helper strings
+    val seg63       = "a" * 63
+    val seq64       = "a" * 64
+    val tooLongName = "a" * 254
+
+    val nameTests = Table(
+      ("name", "expected"),
+      // valid subdomain names
+      ("my-pod-01", true),
+      ("example.com", true),
+      ("foo.bar-baz", true),
+      (seg63, true),
+      (seq64, true),
+      // invalid: uppercase
+      ("Invalid", false),
+      // invalid: empty
+      ("", false),
+      // invalid: starts or ends with a non-alnum character
+      ("-start", false),
+      ("end-", false),
+      (".dotstart", false),
+      ("dotend.", false),
+      // invalid: double-dot or slash
+      ("foo..bar", false),
+      ("/foo", false),
+      ("foo/", false),
+      // invalid: segment too long (>63) or total too long (>253)
+      (tooLongName, false)
+    )
+
+    forAll(nameTests) { (name: String, expected: Boolean) =>
+      K8sValidator.Name.isValid(name) shouldBe expected
+    }
+  }
+
+  test("generateName prefix - isValidPrefix should accept valid prefixes and reject invalid ones") {
+    val validPrefix = "AZaz09-."
+    val dashEnd     = "prefix-"
+    val dotEnd      = "prefix."
+    val max30       = "a" * 30
+    val tooLong30   = "b" * 31
+
+    val prefixTests = Table(
+      ("prefix", "expected"),
+      (validPrefix, true),
+      (dashEnd, true),
+      (dotEnd, true),
+      (max30, true),
+      (tooLong30, false),
+      ("", false),
+      ("invalid/prefix", false),
+      ("with space", false)
+    )
+
+    forAll(prefixTests) { (prefix: String, expected: Boolean) =>
+      K8sValidator.Name.isValidPrefix(prefix) shouldBe expected
+    }
+  }
+}


### PR DESCRIPTION
Extract validation logic into a separate object.

Align validation logic per kubernetes docs:
* object name - https://kubernetes.io/docs/concepts/overview/working-with-objects/names/
* labels - https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#syntax-and-character-set
* annotations - https://kubernetes.io/docs/concepts/overview/working-with-objects/annotations/#syntax-and-character-set