### PR TITLE
Add all jobs succeeded job which will be used as a required check

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -26,3 +26,30 @@ jobs:
   e2e:
     name: E2E
     uses: ./.github/workflows/e2e.yaml
+
+  # A single job that succeeds if all jobs listed under 'needs' succeed.
+  # This allows to configure a single job as a required check.
+  # The 'needed' jobs then can be changed through pull-requests.
+  all-jobs-succeeded:
+    name: All jobs succeeded
+    if: always()
+    # the if clauses below have to reflect the number of jobs listed here
+    needs:
+      - lint
+      - build
+      - build-snapshot
+      - e2e
+    env:
+      RESULTS: ${{ join(needs.*.result, ',') }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Success"
+        # we expect all required jobs to have success result
+        if: env.RESULTS == 'success,success,success,success'
+        run: true
+        shell: bash
+      - name: "Failure"
+        # we expect all required jobs to have success result, fail otherwise
+        if: env.RESULTS != 'success,success,success,success'
+        run: false
+        shell: bash


### PR DESCRIPTION
This PR adds the `all-jobs-succeeded` job identical to the one in Armada, courtesy of @EnricoMi. This job can then be set as required status check.

### Working example - screenshot #1 
As seen in my fork once the job is set as a required check (reviews disabled entirely, CI running, merge button disabled):

![Screenshot 2025-05-13 at 22 36 07](https://github.com/user-attachments/assets/202d8524-4981-4551-8b0b-47efb3dbae11)
---
### Working example - screenshot #2
This is after CI is done successfully:

![Screenshot 2025-05-13 at 23 01 39](https://github.com/user-attachments/assets/39e2ee49-f908-462b-a753-756f55267406)
---

### Working example - screenshot #3
Once CI is done, but check fails, merge is disabled

![Screenshot 2025-05-13 at 23 06 05](https://github.com/user-attachments/assets/f4c9b960-5bf1-471b-9d8a-44e49dc4b308)
---

> [!NOTE]
> As i have admin perms to this repo, after PR is merged, and run once successfully, i will update the current ruleset that currently doesn't have status checks configured