### PR TITLE
Start using dev-e2e script in CI checks

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -84,68 +84,68 @@ runs:
     run: |
       ./armada-spark/scripts/dev-e2e.sh
     shell: bash
-  - name: Patch armada-operator to configure for spark-armada e2e tests
-    run: |
-      # Patch armada-operator
-      patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
-    shell: bash
-  - name: Start Armada Kind cluster
-    id: kind
-    working-directory: armada-operator
-    run: |
-      # Start Armada Kind cluster
-      echo "::group::make kind-all"
-      make kind-all
-      echo "::endgroup::"
+  # - name: Patch armada-operator to configure for spark-armada e2e tests
+  #   run: |
+  #     # Patch armada-operator
+  #     patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
+  #   shell: bash
+  # - name: Start Armada Kind cluster
+  #   id: kind
+  #   working-directory: armada-operator
+  #   run: |
+  #     # Start Armada Kind cluster
+  #     echo "::group::make kind-all"
+  #     make kind-all
+  #     echo "::endgroup::"
 
-      echo "$PWD/bin/app/" >> "$GITHUB_PATH"
-      echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
-    shell: bash
-  - name: Create Armada queue
-    run: |
-      # Create Armada queue
-      echo "::group::armadactl create queue test"
-      until armadactl create queue test 2>&1
-      do
-        echo "::endgroup::"
-        sleep 1
-        echo "::group::armadactl create queue test"
-      done
-      echo "::endgroup::"
+  #     echo "$PWD/bin/app/" >> "$GITHUB_PATH"
+  #     echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
+  #   shell: bash
+  # - name: Create Armada queue
+  #   run: |
+  #     # Create Armada queue
+  #     echo "::group::armadactl create queue test"
+  #     until armadactl create queue test 2>&1
+  #     do
+  #       echo "::endgroup::"
+  #       sleep 1
+  #       echo "::group::armadactl create queue test"
+  #     done
+  #     echo "::endgroup::"
 
-      sleep 60
-    shell: bash
-  - name: Submit SparkPi
-    id: submit
-    run: |
-      # Submit SparkPi
-      echo "::group::submitSparkPi.sh"
-      ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
-      echo "::endgroup::"
+  #     sleep 60
+  #   shell: bash
+  # - name: Submit SparkPi
+  #   id: submit
+  #   run: |
+  #     # Submit SparkPi
+  #     echo "::group::submitSparkPi.sh"
+  #     ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
+  #     echo "::endgroup::"
 
-      while read -r line; do
-        if [[ "$line" == "Submitted driver job with ID:"* ]]; then
-          # strip the leading text…
-          jobid=${line#Submitted driver job with ID:\ }
-          # …then cut off at the first comma
-          jobid=${jobid%%,*}
-          echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
-        fi
-      done < submitSparkPi.log
+  #     while read -r line; do
+  #       if [[ "$line" == "Submitted driver job with ID:"* ]]; then
+  #         # strip the leading text…
+  #         jobid=${line#Submitted driver job with ID:\ }
+  #         # …then cut off at the first comma
+  #         jobid=${jobid%%,*}
+  #         echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
+  #       fi
+  #     done < submitSparkPi.log
       
-      if [[ -z "$jobid" ]]; then
-        echo "No job id detected"
-        exit 1
-      fi
-    shell: bash
-  - name: Watch job
-    run: |
-      # Watch job
-      sleep 10
-      timeout 15m armadactl watch test armada-spark --exit-if-inactive 2>&1 | tee armadactl.watch.log
+  #     if [[ -z "$jobid" ]]; then
+  #       echo "No job id detected"
+  #       exit 1
+  #     fi
+  #   shell: bash
+  # - name: Watch job
+  #   run: |
+  #     # Watch job
+  #     sleep 10
+  #     timeout 15m armadactl watch test armada-spark --exit-if-inactive 2>&1 | tee armadactl.watch.log
 
-      if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
-    shell: bash
+  #     if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
+  #   shell: bash
   - name: Ensure job completed
     run: |
       timeout 5m bash -c '
@@ -186,11 +186,11 @@ runs:
       curl --silent --show-error -X POST "http://localhost:30000/api/v1/jobSpec" --json '{"jobId":"${{ steps.submit.outputs.jobid }}"}' | jq
       echo "::endgroup::"
     shell: bash
-  - name: Confirm # of executors
+  - name: Confirm number of executors
     if: always()
     run: |
-      # Confirm # of executors
-      echo "::group::Confirm # of executors"
+      # Confirm number of executors
+      echo "::group::Confirm number of executors"
       expectedExecutorCount=`grep 'conf spark.executor.instances' ./armada-spark/scripts/submitSparkPi.sh | grep -oP 'spark\.executor\.instances=\K\d+'`
       actualExecutorCount=`grep "ArmadaDriverEndpoint: Registered executor" default.armada-${{ steps.submit.outputs.jobid }}-0.log | wc -l`
       echo executor count expected: $expectedExecutorCount actual: $actualExecutorCount

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -20,11 +20,6 @@ runs:
     uses: actions/checkout@v4
     with:
       path: armada-spark
-  - name: Checkout
-    uses: actions/checkout@v4
-    with:
-      repository: armadaproject/armada-operator
-      path: armada-operator
 
   - name: Restore Maven packages cache
     uses: actions/cache@v4
@@ -41,7 +36,7 @@ runs:
       distribution: 'zulu'
   - name: Setup Go
     id: setup-go
-    uses: ./armada-operator/.github/actions/setup-go-cache
+    uses: armadaproject/armada-operator/.github/actions/setup-go-cache@main
     with:
       cache-prefix: go-e2e
 

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -81,6 +81,7 @@ runs:
       echo "::endgroup::"
     shell: bash
   - name: Test job processing
+    id: submit
     run: |
       ./armada-spark/scripts/dev-e2e.sh
     shell: bash

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -83,70 +83,10 @@ runs:
   - name: Test job processing
     id: submit
     run: |
+      echo "::group::dev-e2e.sh"
       ./armada-spark/scripts/dev-e2e.sh
+      echo "::endgroup::"
     shell: bash
-  # - name: Patch armada-operator to configure for spark-armada e2e tests
-  #   run: |
-  #     # Patch armada-operator
-  #     patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
-  #   shell: bash
-  # - name: Start Armada Kind cluster
-  #   id: kind
-  #   working-directory: armada-operator
-  #   run: |
-  #     # Start Armada Kind cluster
-  #     echo "::group::make kind-all"
-  #     make kind-all
-  #     echo "::endgroup::"
-
-  #     echo "$PWD/bin/app/" >> "$GITHUB_PATH"
-  #     echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
-  #   shell: bash
-  # - name: Create Armada queue
-  #   run: |
-  #     # Create Armada queue
-  #     echo "::group::armadactl create queue test"
-  #     until armadactl create queue test 2>&1
-  #     do
-  #       echo "::endgroup::"
-  #       sleep 1
-  #       echo "::group::armadactl create queue test"
-  #     done
-  #     echo "::endgroup::"
-
-  #     sleep 60
-  #   shell: bash
-  # - name: Submit SparkPi
-  #   id: submit
-  #   run: |
-  #     # Submit SparkPi
-  #     echo "::group::submitSparkPi.sh"
-  #     ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
-  #     echo "::endgroup::"
-
-  #     while read -r line; do
-  #       if [[ "$line" == "Submitted driver job with ID:"* ]]; then
-  #         # strip the leading text…
-  #         jobid=${line#Submitted driver job with ID:\ }
-  #         # …then cut off at the first comma
-  #         jobid=${jobid%%,*}
-  #         echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
-  #       fi
-  #     done < submitSparkPi.log
-      
-  #     if [[ -z "$jobid" ]]; then
-  #       echo "No job id detected"
-  #       exit 1
-  #     fi
-  #   shell: bash
-  # - name: Watch job
-  #   run: |
-  #     # Watch job
-  #     sleep 10
-  #     timeout 15m armadactl watch test armada-spark --exit-if-inactive 2>&1 | tee armadactl.watch.log
-
-  #     if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
-  #   shell: bash
   - name: Ensure job completed
     run: |
       timeout 5m bash -c '

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -84,61 +84,61 @@ runs:
     run: |
       ./armada-spark/scripts/dev-e2e.sh
     shell: bash
-  # - name: Patch armada-operator to configure for spark-armada e2e tests
-  #   run: |
-  #     # Patch armada-operator
-  #     patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
-  #   shell: bash
-  # - name: Start Armada Kind cluster
-  #   id: kind
-  #   working-directory: armada-operator
-  #   run: |
-  #     # Start Armada Kind cluster
-  #     echo "::group::make kind-all"
-  #     make kind-all
-  #     echo "::endgroup::"
+  - name: Patch armada-operator to configure for spark-armada e2e tests
+    run: |
+      # Patch armada-operator
+      patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
+    shell: bash
+  - name: Start Armada Kind cluster
+    id: kind
+    working-directory: armada-operator
+    run: |
+      # Start Armada Kind cluster
+      echo "::group::make kind-all"
+      make kind-all
+      echo "::endgroup::"
 
-  #     echo "$PWD/bin/app/" >> "$GITHUB_PATH"
-  #     echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
-  #   shell: bash
-  # - name: Create Armada queue
-  #   run: |
-  #     # Create Armada queue
-  #     echo "::group::armadactl create queue test"
-  #     until armadactl create queue test 2>&1
-  #     do
-  #       echo "::endgroup::"
-  #       sleep 1
-  #       echo "::group::armadactl create queue test"
-  #     done
-  #     echo "::endgroup::"
+      echo "$PWD/bin/app/" >> "$GITHUB_PATH"
+      echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
+    shell: bash
+  - name: Create Armada queue
+    run: |
+      # Create Armada queue
+      echo "::group::armadactl create queue test"
+      until armadactl create queue test 2>&1
+      do
+        echo "::endgroup::"
+        sleep 1
+        echo "::group::armadactl create queue test"
+      done
+      echo "::endgroup::"
 
-  #     sleep 60
-  #   shell: bash
-  # - name: Submit SparkPi
-  #   id: submit
-  #   run: |
-  #     # Submit SparkPi
-  #     echo "::group::submitSparkPi.sh"
-  #     ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
-  #     echo "::endgroup::"
+      sleep 60
+    shell: bash
+  - name: Submit SparkPi
+    id: submit
+    run: |
+      # Submit SparkPi
+      echo "::group::submitSparkPi.sh"
+      ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
+      echo "::endgroup::"
 
-  #     while read line; do
-  #       if [[ "$line" == "Driver JobID:"* ]]; then
-  #         read driver job jobid error none <<< "$line"
-  #         echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
-  #       fi
-  #     done < submitSparkPi.log
-  #     if [[ -z "$jobid" ]]; then echo "No job id detected"; exit 1; fi
-  #   shell: bash
-  # - name: Watch job
-  #   run: |
-  #     # Watch job
-  #     sleep 10
-  #     timeout 15m armadactl watch test driver --exit-if-inactive 2>&1 | tee armadactl.watch.log
+      while read line; do
+        if [[ "$line" == "Driver JobID:"* ]]; then
+          read driver job jobid error none <<< "$line"
+          echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
+        fi
+      done < submitSparkPi.log
+      if [[ -z "$jobid" ]]; then echo "No job id detected"; exit 1; fi
+    shell: bash
+  - name: Watch job
+    run: |
+      # Watch job
+      sleep 10
+      timeout 15m armadactl watch test driver --exit-if-inactive 2>&1 | tee armadactl.watch.log
 
-  #     if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
-  #   shell: bash
+      if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
+    shell: bash
   - name: Inspect k8s pods
     id: k8s-pods
     if: always() && steps.kind.outcome == 'success'

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -80,61 +80,65 @@ runs:
       ./armada-spark/scripts/createImage.sh
       echo "::endgroup::"
     shell: bash
-  - name: Patch armada-operator to configure for spark-armada e2e tests
+  - name: Test job processing
     run: |
-      # Patch armada-operator
-      patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
+      ./armada-spark/scripts/dev-e2e.sh
     shell: bash
-  - name: Start Armada Kind cluster
-    id: kind
-    working-directory: armada-operator
-    run: |
-      # Start Armada Kind cluster
-      echo "::group::make kind-all"
-      make kind-all
-      echo "::endgroup::"
+  # - name: Patch armada-operator to configure for spark-armada e2e tests
+  #   run: |
+  #     # Patch armada-operator
+  #     patch -p1 -d ./armada-operator/ < ./armada-spark/e2e/armada-operator.patch
+  #   shell: bash
+  # - name: Start Armada Kind cluster
+  #   id: kind
+  #   working-directory: armada-operator
+  #   run: |
+  #     # Start Armada Kind cluster
+  #     echo "::group::make kind-all"
+  #     make kind-all
+  #     echo "::endgroup::"
 
-      echo "$PWD/bin/app/" >> "$GITHUB_PATH"
-      echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
-    shell: bash
-  - name: Create Armada queue
-    run: |
-      # Create Armada queue
-      echo "::group::armadactl create queue test"
-      until armadactl create queue test 2>&1
-      do
-        echo "::endgroup::"
-        sleep 1
-        echo "::group::armadactl create queue test"
-      done
-      echo "::endgroup::"
+  #     echo "$PWD/bin/app/" >> "$GITHUB_PATH"
+  #     echo "$PWD/bin/tooling/" >> "$GITHUB_PATH"
+  #   shell: bash
+  # - name: Create Armada queue
+  #   run: |
+  #     # Create Armada queue
+  #     echo "::group::armadactl create queue test"
+  #     until armadactl create queue test 2>&1
+  #     do
+  #       echo "::endgroup::"
+  #       sleep 1
+  #       echo "::group::armadactl create queue test"
+  #     done
+  #     echo "::endgroup::"
 
-      sleep 60
-    shell: bash
-  - name: Submit SparkPi
-    id: submit
-    run: |
-      # Submit SparkPi
-      echo "::group::submitSparkPi.sh"
-      ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
-      echo "::endgroup::"
+  #     sleep 60
+  #   shell: bash
+  # - name: Submit SparkPi
+  #   id: submit
+  #   run: |
+  #     # Submit SparkPi
+  #     echo "::group::submitSparkPi.sh"
+  #     ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
+  #     echo "::endgroup::"
 
-      while read line; do
-        if [[ "$line" == "Driver JobID:"* ]]; then
-          read driver job jobid error none <<< "$line"
-          echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
-        fi
-      done < submitSparkPi.log
-      if [[ -z "$jobid" ]]; then echo "No job id detected"; exit 1; fi
-    shell: bash
-  - name: Watch job
-    run: |
-      # Watch job
-      sleep 10
-      timeout 15m armadactl watch test driver --exit-if-inactive 2>&1 | tee armadactl.watch.log
+  #     while read line; do
+  #       if [[ "$line" == "Driver JobID:"* ]]; then
+  #         read driver job jobid error none <<< "$line"
+  #         echo "jobid=$jobid" >> "$GITHUB_OUTPUT"
+  #       fi
+  #     done < submitSparkPi.log
+  #     if [[ -z "$jobid" ]]; then echo "No job id detected"; exit 1; fi
+  #   shell: bash
+  # - name: Watch job
+  #   run: |
+  #     # Watch job
+  #     sleep 10
+  #     timeout 15m armadactl watch test driver --exit-if-inactive 2>&1 | tee armadactl.watch.log
 
-      if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
-    shell: bash
+  #     if grep "Job failed:" armadactl.watch.log; then echo "Job failed"; exit 1; fi
+  #   shell: bash
   - name: Inspect k8s pods
     id: k8s-pods
     if: always() && steps.kind.outcome == 'success'

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -10,14 +10,14 @@ AOREPO='https://github.com/armadaproject/armada-operator.git'
 ARMADACTL_VERSION='0.19.1'
 JOB_DETAILS="${JOB_DETAILS:-0}"
 
-now=$(date +'%Y%m%d%H%M%S')
-JOBSET="armada-spark-$now" # users may run this multiple times on same cluster
-
 if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
   AOHOME="$scripts/../armada-operator"
+  JOBSET='armada-spark'
   JOB_DETAILS=1
 else
+  now=$(date +'%Y%m%d%H%M%S')
   AOHOME="$scripts/../../armada-operator"
+  JOBSET="armada-spark-$now" # interactive users may run this multiple times on same cluster
   GITHUB_OUTPUT=/dev/stdout
 fi
 

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -166,7 +166,7 @@ main() {
   test -d "$scripts/.tmp" || mkdir "$scripts/.tmp"
   TMPDIR="$scripts/.tmp" "$AOHOME/bin/tooling/kind" load docker-image "$IMAGE_NAME" --name armada
 
-  PATH="$AOHOME/bin/tooling/:$PATH" "$scripts/submitSparkPi.sh" 2>&1 | \
+  PATH="$scripts:$AOHOME/bin/tooling/:$PATH" "$scripts/submitSparkPi.sh" 2>&1 | \
     tee submitSparkPi.log | log_group "Submitting SparkPI job"
 
   DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -181,8 +181,8 @@ main() {
 
   PATH="$scripts:$AOHOME/bin/tooling/:$PATH" JOBSET="$JOBSET" "$scripts/submitSparkPi.sh" 2>&1 | \
     tee submitSparkPi.log
-  DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
-  EXECUTOR_JOBIDS=$(grep 'executor job with ID:' submitSparkPi.log | awk '{print $6}')
+  DRIVER_JOBID=$(grep '^Submitted driver job with ID:' submitSparkPi.log | awk '{print $6}' | sed -e 's/,$//')
+  EXECUTOR_JOBIDS=$(grep '^Submitted executor job with ID:' submitSparkPi.log | awk '{print $6}' | sed -e 's/,$//')
 
   echo "::group::submit"
   echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT"

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -181,7 +181,7 @@ main() {
     EXECUTOR_JOBIDS=$(grep 'executor job with ID:' submitSparkPi.log | awk '{print $6}')
 
     echo "---------- about to run armadactl watch ----"
-    (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" driver --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
+    (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" armada-spark --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
      if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi) | log_group "Watching Driver Job"
 
     echo "---------- about to curl for job spec ----"

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-set -euo pipefail
+#set -euo pipefail
 
 scripts="$(cd "$(dirname "$0")"; pwd)"
 source "$scripts"/init.sh

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -169,11 +169,12 @@ main() {
   PATH="$scripts:$AOHOME/bin/tooling/:$PATH" "$scripts/submitSparkPi.sh" 2>&1 | \
     tee submitSparkPi.log | log_group "Submitting SparkPI job"
 
-  DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
-  EXECUTOR_JOBIDS=$(grep '^Executor JobID:' submitSparkPi.log | awk '{print $3}')
-
   if [ "$JOB_DETAILS" = 1 ]; then
-    sleep 5   # wait a moment for Armada to schedule & run the job
+    sleep 10   # wait a moment for Armada to schedule & run the job
+
+    echo "---------- about to check for driver and executor job ids ----"
+    DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
+    EXECUTOR_JOBIDS=$(grep '^Executor JobID:' submitSparkPi.log | awk '{print $3}')
 
     (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" driver --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
      if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi) | log_group "Watching Driver Job"

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -184,7 +184,9 @@ main() {
   DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
   EXECUTOR_JOBIDS=$(grep 'executor job with ID:' submitSparkPi.log | awk '{print $6}')
 
-  echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT" | log_group "submit"
+  echo "::group::submit"
+  echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT"
+  echo "::endgroup::"
 
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 10   # wait a moment for Armada to schedule & run the job

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -184,9 +184,11 @@ main() {
   DRIVER_JOBID=$(grep '^Submitted driver job with ID:' submitSparkPi.log | awk '{print $6}' | sed -e 's/,$//')
   EXECUTOR_JOBIDS=$(grep '^Submitted executor job with ID:' submitSparkPi.log | awk '{print $6}' | sed -e 's/,$//')
 
-  echo "::group::submit"
-  echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT"
-  echo "::endgroup::"
+  if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+    echo "::group::submit"
+    echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT"
+    echo "::endgroup::"
+  fi
 
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 10   # wait a moment for Armada to schedule & run the job

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -15,9 +15,9 @@ if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
   JOBSET='armada-spark'
   JOB_DETAILS=1
 else
-  now=$(date +'%Y%m%d%H%M%S')
   AOHOME="$scripts/../../armada-operator"
-  JOBSET="armada-spark-$now" # interactive users may run this multiple times on same cluster
+  now=$(date +'%Y%m%d%H%M%S')
+  JOBSET="armada-spark-$now" # interactive users may run this multiple times on same Armada cluster
   GITHUB_OUTPUT=/dev/stdout
 fi
 

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -141,7 +141,7 @@ main() {
   fi
   echo "Checking for armadactl .."
   if ! test -x "$scripts"/armadactl; then
-    fetch-armadactl | log_group "Fetching armadactl"
+    fetch-armadactl 2>&1 | log_group "Fetching armadactl"
   fi
 
   echo "Checking if image $IMAGE_NAME is available"
@@ -175,6 +175,8 @@ main() {
    TMPDIR="$scripts/.tmp" "$AOHOME/bin/tooling/kind" load docker-image "$IMAGE_NAME" --name armada 2>&1) \
    | log_group "Loading Docker image $IMAGE_NAME into Armada cluster";
 
+  # Pause to ensure that Armada cluster is fully ready to accept jobs; without this,
+  # proceeding immediately causes sporadic immediate job rejections by Armada
   sleep 30
 
   PATH="$scripts:$AOHOME/bin/tooling/:$PATH" JOBSET="$JOBSET" "$scripts/submitSparkPi.sh" 2>&1 | \

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -11,6 +11,10 @@ AOREPO='https://github.com/armadaproject/armada-operator.git'
 ARMADACTL_VERSION='0.19.1'
 JOB_DETAILS=1
 
+if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
+  AOHOME="$scripts/../armada-operator"
+fi
+
 GREEN='\033[0;32m'
 RED='\033[0;31m'
 NC='\033[0m'

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -175,7 +175,7 @@ main() {
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 10   # wait a moment for Armada to schedule & run the job
 
-    (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" "$JOBSET" --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
+    (timeout 3m "$scripts"/armadactl watch "$ARMADA_QUEUE" "$JOBSET" --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
      if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi) | log_group "Watching Driver Job"
 
     curl --silent --show-error -X POST "http://localhost:30000/api/v1/jobSpec" \

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -174,7 +174,7 @@ main() {
 
     echo "---------- about to check for driver and executor job ids ----"
     DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
-    EXECUTOR_JOBIDS=$(grep '^Executor JobID:' submitSparkPi.log | awk '{print $3}')
+    EXECUTOR_JOBIDS=$(grep 'executor job with ID:' submitSparkPi.log | awk '{print $6}')
 
     echo "---------- about to run armadactl watch ----"
     (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" driver --exit-if-inactive 2>&1 | tee armadactl.watch.log; \

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -187,12 +187,9 @@ main() {
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 10   # wait a moment for Armada to schedule & run the job
 
-
-    echo "---------- about to run armadactl watch ----"
     (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" "$JOBSET" --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
      if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi) | log_group "Watching Driver Job"
 
-    echo "---------- about to curl for job spec ----"
     curl --silent --show-error -X POST "http://localhost:30000/api/v1/jobSpec" \
       --json "{\"jobId\":\"$DRIVER_JOBID\"}" | jq | log_group "Driver Job Spec  $DRIVER_JOBID"
 

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-#set -euo pipefail
+set -euo pipefail
 
 scripts="$(cd "$(dirname "$0")"; pwd)"
 source "$scripts"/init.sh

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -163,6 +163,7 @@ main() {
   armadactl-retry create queue "$ARMADA_QUEUE" 2>&1 | log_group "Creating $ARMADA_QUEUE queue"
 
   echo "Loading Docker image $IMAGE_NAME into Armada cluster"
+  test -d "$scripts/.tmp" || mkdir "$scripts/.tmp"
   TMPDIR="$scripts/.tmp" "$AOHOME/bin/tooling/kind" load docker-image "$IMAGE_NAME" --name armada
 
   PATH="$AOHOME/bin/tooling/:$PATH" "$scripts/submitSparkPi.sh" 2>&1 | \

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -175,9 +175,9 @@ main() {
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 5   # wait a moment for Armada to schedule & run the job
 
-    (timeout 1m "$scripts"/armadactl watch test driver --exit-if-inactive 2>&1 | tee armadactl.watch.log
-    if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi ) \
-      | log_group "Watching Driver Job"
+    (timeout 1m "$scripts"/armadactl watch "$ARMADA_QUEUE" driver --exit-if-inactive 2>&1 | tee armadactl.watch.log; \
+     if grep "Job failed:" armadactl.watch.log; then err "Job failed"; exit 1; fi) | log_group "Watching Driver Job"
+
     curl --silent --show-error -X POST "http://localhost:30000/api/v1/jobSpec" \
       --json "{\"jobId\":\"$DRIVER_JOBID\"}" | jq | log_group "Driver Job Spec  $DRIVER_JOBID"
 

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -182,7 +182,7 @@ main() {
   DRIVER_JOBID=$(grep '^Driver JobID:' submitSparkPi.log | awk '{print $3}')
   EXECUTOR_JOBIDS=$(grep 'executor job with ID:' submitSparkPi.log | awk '{print $6}')
 
-  echo "jobid=$DRIVER_JOBID" | tee "$GITHUB_OUTPUT" | log_group "submit"
+  echo "jobid=$DRIVER_JOBID" >> "$GITHUB_OUTPUT" | log_group "submit"
 
   if [ "$JOB_DETAILS" = 1 ]; then
     sleep 10   # wait a moment for Armada to schedule & run the job

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -10,14 +10,14 @@ AOREPO='https://github.com/armadaproject/armada-operator.git'
 ARMADACTL_VERSION='0.19.1'
 JOB_DETAILS="${JOB_DETAILS:-0}"
 
+now=$(date +'%Y%m%d%H%M%S')
+JOBSET="armada-spark-$now" # users may run this multiple times on same cluster
+
 if [ "${GITHUB_ACTIONS:-false}" == "true" ]; then
   AOHOME="$scripts/../armada-operator"
-  JOBSET='armada-spark'
   JOB_DETAILS=1
 else
-  now=$(date +'%Y%m%d%H%M%S')
   AOHOME="$scripts/../../armada-operator"
-  JOBSET="armada-spark-$now" # interactive users may run this multiple times on same cluster
   GITHUB_OUTPUT=/dev/stdout
 fi
 

--- a/scripts/submitSparkPi.sh
+++ b/scripts/submitSparkPi.sh
@@ -5,6 +5,8 @@ set -euo pipefail
 scripts="$(cd "$(dirname "$0")"; pwd)"
 source "$scripts/init.sh"
 
+JOBSET="${JOBSET:-armada-spark}"
+
 if [ "${INCLUDE_PYTHON}" == "false" ]; then
     echo Running Scala Spark
     NAME=spark-pi
@@ -38,7 +40,7 @@ docker run --rm --network host $IMAGE_NAME \
     $CLASS_PROMPT $CLASS_ARG \
     --conf spark.armada.internalUrl=armada-server.armada:50051 \
     --conf spark.armada.queue=$ARMADA_QUEUE \
-    --conf spark.armada.jobSetId=armada-spark \
+    --conf spark.armada.jobSetId="$JOBSET" \
     --conf spark.executor.instances=2 \
     --conf spark.armada.container.image=$IMAGE_NAME \
     --conf spark.armada.lookouturl=$ARMADA_LOOKOUT_URL \

--- a/scripts/submitSparkPi.sh
+++ b/scripts/submitSparkPi.sh
@@ -39,7 +39,7 @@ docker run --rm --network host $IMAGE_NAME \
     --conf spark.armada.internalUrl=armada-server.armada:50051 \
     --conf spark.armada.queue=$ARMADA_QUEUE \
     --conf spark.armada.jobSetId=armada-spark \
-    --conf spark.executor.instances=4 \
+    --conf spark.executor.instances=2 \
     --conf spark.armada.container.image=$IMAGE_NAME \
     --conf spark.armada.lookouturl=$ARMADA_LOOKOUT_URL \
     --conf spark.armada.scheduling.nodeUniformity=armada-spark \

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -261,7 +261,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       s"Submitted driver job for queue ${armadaJobConfig.queue} with JobSet ID ${armadaJobConfig.jobSetId}"
     )
     log(
-      s"Driver Job ID: $driverJobId, Error: ${driverResponse.jobResponseItems.head.error}"
+      s"Driver JobID: $driverJobId  Error: ${driverResponse.jobResponseItems.head.error}"
     )
 
     val executorsResponse =

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -258,7 +258,10 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       armadaClient.submitJobs(armadaJobConfig.queue, armadaJobConfig.jobSetId, Seq(driver))
     val driverJobId = driverResponse.jobResponseItems.head.jobId
     log(
-      s"Submitted driver job with ID: $driverJobId, Error: ${driverResponse.jobResponseItems.head.error}"
+      s"Submitted driver job for queue ${armadaJobConfig.queue} with JobSet ID ${armadaJobConfig.jobSetId}"
+    )
+    log(
+      s"Driver Job ID: $driverJobId, Error: ${driverResponse.jobResponseItems.head.error}"
     )
 
     val executorsResponse =

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -268,7 +268,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       armadaClient.submitJobs(armadaJobConfig.queue, armadaJobConfig.jobSetId, executors)
     val executorJobIds = executorsResponse.jobResponseItems.map(item => {
       log(
-        s"Submitted executor job with ID: ${item.jobId}, Error: ${item.error}"
+        s"Submitted executor job with ID: ${item.jobId}  Error: ${item.error}"
       )
       item.jobId
     })


### PR DESCRIPTION
These changes replace a subset of the existing GH CI Actions script for doing e2e tests. The `dev-e2e.sh` was originally authored for casual, interactive armada-spark developer use, and is enhanced here to be usable within GH Actions CI checks.  Add GH Actions group markers in logging; clean up logging messages; replace some of existing GH Actions e2e script with invocation of dev-e2e.sh.

Fixes https://github.com/G-Research/spark/issues/80