### PR TITLE
Allow building of python 33 armada-spark docker images

### DIFF
--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -34,6 +34,19 @@ runs:
       restore-keys:
         ${{ runner.os }}-mvn-e2e-${{ inputs.spark_version }}-${{ inputs.scala_version }}-${{ hashFiles('armada-spark/pom.xml') }}
         ${{ runner.os }}-mvn-e2e-${{ inputs.spark_version }}-${{ inputs.scala_version }}-
+  - name: Move docker
+    run: |
+      # Moving docker to save space
+      echo "::group::moving Docker"
+      df -h /mnt
+      sudo systemctl stop docker
+      sudo cp -rpd /var/lib/docker /mnt
+      sudo mv /var/lib/docker /var/lib/docker.old
+      sudo ln -s /mnt/docker /var/lib
+      sudo systemctl start docker
+      df -h /mnt
+      echo "::endgroup::"
+    shell: bash
   - name: Setup JDK
     uses: actions/setup-java@v4
     with:
@@ -77,7 +90,7 @@ runs:
     run: |
       # Build image
       echo "::group::createImage.sh"
-      ./armada-spark/scripts/createImage.sh
+      ./armada-spark/scripts/createImage.sh -p
       echo "::endgroup::"
     shell: bash
   - name: Patch armada-operator to configure for spark-armada e2e tests
@@ -116,7 +129,7 @@ runs:
     run: |
       # Submit SparkPi
       echo "::group::submitSparkPi.sh"
-      ./armada-spark/scripts/submitSparkPi.sh 2>&1 | tee submitSparkPi.log
+      ./armada-spark/scripts/submitSparkPi.sh -p 2>&1 | tee submitSparkPi.log
       echo "::endgroup::"
 
       while read -r line; do

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -22,22 +22,3 @@ FROM ${spark_base_image_prefix}:${spark_base_image_tag}
 ARG scala_binary_version=2.13
 
 COPY target/armada-cluster-manager_${scala_binary_version}-*-all.jar /opt/spark/jars/
-
-WORKDIR /
-
-# Reset to root to run installation tasks
-USER 0
-
-ARG include_python=true
-RUN if [ "$include_python" = "true" ]; then \
-    apt-get update && \
-    apt install -y python3 python3-pip && \
-    pip3 install --upgrade pip setuptools; \
-  fi
-
-WORKDIR /opt/spark/work-dir
-ENTRYPOINT [ "/opt/entrypoint.sh" ]
-
-# Specify the User that the actual main process will run as
-ARG spark_uid=185
-USER ${spark_uid}

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -7,19 +7,21 @@ root="$(cd "$(dirname "$0")/.."; pwd)"
 scripts="$(cd "$(dirname "$0")"; pwd)"
 source "$scripts/init.sh"
 
-if [ "${INCLUDE_PYTHON}" == "false" ]; then
-    echo Building image without Python.
-else
-    echo Building Python image.
-fi
-
 image_prefix=apache/spark
 image_tag="$SPARK_VERSION-scala$SCALA_BIN_VERSION-java${JAVA_VERSION:-17}-ubuntu"
 
 # There are no Docker images for Spark 3 and Scala 2.13, as well as for Spark 3.3.4 and any Scala
 if [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] || [[ "$SPARK_VERSION" == "3.3.4" ]] ); then
   echo Checking for images for spark: $SPARK_VERSION scala: $SCALA_BIN_VERSION
-  image_prefix=spark-py
+  if [ "${INCLUDE_PYTHON}" == "false" ]; then
+      echo Building image without Python.
+      image_prefix=spark
+      extra_build_params=""
+  else
+      echo Building Python image.
+      image_prefix=spark-py
+      extra_build_params=" -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile "
+  fi
   if ! docker image inspect "$image_prefix:$image_tag" >/dev/null 2>/dev/null; then
     echo "There are no Docker images released for Spark $SPARK_VERSION and Scala $SCALA_BIN_VERSION."
     echo "A Docker image has to be built from Spark sources locally."
@@ -39,21 +41,15 @@ if [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] || 
     ./build/mvn --batch-mode clean
     ./build/mvn --batch-mode package -pl examples
     ./build/mvn --batch-mode package -Pkubernetes -Pscala-$SCALA_BIN_VERSION -pl assembly
-    # including python in spark image
-    ./bin/docker-image-tool.sh -t "$image_tag" -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
-    # remove extra image created by docker-image-tool.sh
-    docker image rm spark:$image_tag
-
+    ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
     cd ..
   fi
 fi
 
-# including python in the armada-spark image slows the build significantly, so don't include it by default
 docker build \
   --tag $IMAGE_NAME \
   --build-arg spark_base_image_prefix=$image_prefix \
   --build-arg spark_base_image_tag=$image_tag \
   --build-arg scala_binary_version=$SCALA_BIN_VERSION \
-  --build-arg include_python=$INCLUDE_PYTHON \
   -f "$root/docker/Dockerfile" \
   "$root"


### PR DESCRIPTION
I also had to modify the github actions to move /var/lib/docker to the /mnt drive to make room for the new image.

https://github.com/G-Research/spark/issues/73