### PR TITLE
Add secret key selector support

### DIFF
--- a/conf/spark-defaults.conf
+++ b/conf/spark-defaults.conf
@@ -17,7 +17,7 @@ spark.armada.internalUrl unused
 #spark.armada.executor.request.memory 510Mi
 
 
-# s3 config:
+# example s3/history server config:
 #spark.hadoop.fs.s3a.path.style.access True
 #spark.hadoop.fs.s3a.endpoint https://xx.com
 #spark.eventLog.enabled true

--- a/conf/spark-defaults.conf
+++ b/conf/spark-defaults.conf
@@ -16,3 +16,14 @@ spark.armada.internalUrl unused
 #spark.armada.executor.request.cores 100m
 #spark.armada.executor.request.memory 510Mi
 
+
+# s3 config:
+#spark.hadoop.fs.s3a.path.style.access True
+#spark.hadoop.fs.s3a.endpoint https://xx.com
+#spark.eventLog.enabled true
+#spark.eventLog.dir s3a://bucket/xx99
+#spark.history.fs.logDirectory s3a://bucket/xx99
+#spark.kubernetes.driver.secretKeyRef.AWS_SECRET_KEY=key1:secret_key
+#spark.kubernetes.executor.secretKeyRef.AWS_SECRET_KEY=key1:secret_key
+#spark.kubernetes.driver.secretKeyRef.AWS_ACCESS_KEY_ID=key1:access_key
+#spark.kubernetes.executor.secretKeyRef.AWS_ACCESS_KEY_ID=key1:access_key

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,5 +21,6 @@ FROM ${spark_base_image_prefix}:${spark_base_image_tag}
 
 ARG scala_binary_version=2.13
 
-COPY extraFiles /opt/spark/extraFiles
 COPY target/armada-cluster-manager_${scala_binary_version}-*-all.jar /opt/spark/jars/
+COPY extraFiles /opt/spark/extraFiles
+COPY extraJars/* /opt/spark/jars

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -238,6 +238,7 @@ section of the README for more information.
 
 Any files you wish to be included in the image, (e.g. Python scripts or Scala / Java jar files) should be copied into the [extraFiles](../extraFiles) directory.  They will appear on the image in the /opt/spark/extraFiles directory.
 
+Any jars you want added to the classpath should be copied into the [extraJars](../extraJars) directory.
 
 # Architecture & Design
 

--- a/extraJars/.gitignore
+++ b/extraJars/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore

--- a/extraJars/.gitignore
+++ b/extraJars/.gitignore
@@ -1,4 +1,0 @@
-# Ignore everything in this directory
-*
-# Except this file
-!.gitignore

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -704,6 +704,10 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       executorFeatureStepContainer: Option[Container] = None
   )
 
+  private def removeAuthToken(seq: Seq[String]): Seq[String] = {
+    seq.grouped(2).toSeq.filter(!_(1).contains("auth.token")).flatten
+    }
+
   private[submit] def createDriverJob(
       armadaJobConfig: ArmadaJobConfig,
       resolvedConfig: ResolvedJobConfig,
@@ -712,7 +716,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       primaryResource: Seq[String],
       confSeq: Seq[String]
   ): api.submit.JobSubmitRequestItem = {
-    val driverArgs = confSeq ++ primaryResource ++ clientArguments.driverArgs
+    val driverArgs = removeAuthToken(confSeq ++ primaryResource ++ clientArguments.driverArgs)
 
     mergeDriverTemplate(
       armadaJobConfig.driverJobItemTemplate,

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -716,7 +716,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       primaryResource: Seq[String],
       confSeq: Seq[String]
   ): api.submit.JobSubmitRequestItem = {
-    val driverArgs = removeAuthToken(confSeq ++ primaryResource ++ clientArguments.driverArgs)
+    val driverArgs = removeAuthToken(confSeq) ++ primaryResource ++ clientArguments.driverArgs
 
     mergeDriverTemplate(
       armadaJobConfig.driverJobItemTemplate,

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -706,7 +706,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
 
   private def removeAuthToken(seq: Seq[String]): Seq[String] = {
     seq.grouped(2).toSeq.filter(!_(1).contains("auth.token")).flatten
-    }
+  }
 
   private[submit] def createDriverJob(
       armadaJobConfig: ArmadaJobConfig,

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
@@ -38,7 +38,7 @@ private[submit] class ConfigGenerator(val prefix: String, val conf: SparkConf) {
 
   private val confFiles = getConfFiles
   private def getConfFiles: Array[File] = {
-    val VALID_FILE_NAME_REGEX = "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
+    val VALID_FILE_NAME_REGEX = "([\\w][-\\w.]*)?[\\w]"
     confDir
       .map(new File(_))
       .filter(_.isDirectory)

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
@@ -38,10 +38,11 @@ private[submit] class ConfigGenerator(val prefix: String, val conf: SparkConf) {
 
   private val confFiles = getConfFiles
   private def getConfFiles: Array[File] = {
+    val VALID_FILE_NAME_REGEX = "([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9]"
     confDir
       .map(new File(_))
       .filter(_.isDirectory)
-      .map(_.listFiles.filter(!_.isDirectory))
+      .map(_.listFiles.filter(f => !f.isDirectory && f.getName.matches(VALID_FILE_NAME_REGEX)))
       .getOrElse(Array.empty)
   }
 

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
@@ -75,8 +75,8 @@ private[spark] object JobTemplateLoader {
     }
   }
 
-  /** Custom deserializer for SecretKeySelector objects. Handles the case where the localObjectReference
-    * (name field) is elided.
+  /** Custom deserializer for SecretKeySelector objects. Handles the case where the
+    * localObjectReference (name field) is elided.
     */
   private class SecretKeySelectorDeserializer extends JsonDeserializer[SecretKeySelector] {
     @throws(classOf[JsonProcessingException])

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
@@ -85,23 +85,12 @@ private[spark] object JobTemplateLoader {
       val node = p.getCodec.readTree(p).asInstanceOf[JsonNode]
 
       // Extract the key field
-      val key = if (node.has("key")) {
-        Option(node.get("key").asText())
-      } else {
-        None
-      }
+      val key = Option(node.get("key")).map(_.asText())
 
       // Extract the name field (which might be elided)
-      val localObjectRef = if (node.has("name")) {
-        val nameValue = node.get("name").asText()
-        if (nameValue != null && nameValue.nonEmpty) {
-          Option(new LocalObjectReference(Option(nameValue)))
-        } else {
-          None
-        }
-      } else {
-        None
-      }
+      val localObjectRef = Option(node.get("name"))
+        .filter(n => Option(n.asText()).exists(_.nonEmpty))
+        .map(n => new LocalObjectReference(Option(n.asText())))
 
       // Create a new SecretKeySelector with the extracted fields
       new SecretKeySelector(localObjectRef, key)

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
@@ -22,12 +22,14 @@ import com.fasterxml.jackson.databind.{
   DeserializationContext,
   DeserializationFeature,
   JsonDeserializer,
+  JsonNode,
   ObjectMapper
 }
 import com.fasterxml.jackson.databind.module.SimpleModule
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
+import k8s.io.api.core.v1.generated.{LocalObjectReference, SecretKeySelector}
 
 import java.io.{File, InputStream}
 import java.net.{HttpURLConnection, URL}
@@ -51,9 +53,10 @@ private[spark] object JobTemplateLoader {
     mapper.registerModule(DefaultScalaModule)
     mapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
 
-    // Register custom deserializer for Quantity class
+    // Register custom deserializers
     val module = new SimpleModule()
     module.addDeserializer(classOf[Quantity], new QuantityDeserializer())
+    module.addDeserializer(classOf[SecretKeySelector], new SecretKeySelectorDeserializer())
     mapper.registerModule(module)
 
     mapper
@@ -66,9 +69,42 @@ private[spark] object JobTemplateLoader {
     @throws(classOf[JsonProcessingException])
     override def deserialize(p: JsonParser, ctxt: DeserializationContext): Quantity = {
       Some(p.getValueAsString)
-        .filter(s => s != null && !s.isEmpty)
+        .filter(s => s != null && s.nonEmpty)
         .map(s => new Quantity(Option(s)))
         .orNull
+    }
+  }
+
+  /** Custom deserializer for SecretKeySelector objects. Handles the case where the localObjectReference
+    * (name field) is elided.
+    */
+  private class SecretKeySelectorDeserializer extends JsonDeserializer[SecretKeySelector] {
+    @throws(classOf[JsonProcessingException])
+    override def deserialize(p: JsonParser, ctxt: DeserializationContext): SecretKeySelector = {
+      // Use the codec to read the JSON as a tree
+      val node = p.getCodec.readTree(p).asInstanceOf[JsonNode]
+
+      // Extract the key field
+      val key = if (node.has("key")) {
+        Option(node.get("key").asText())
+      } else {
+        None
+      }
+
+      // Extract the name field (which might be elided)
+      val localObjectRef = if (node.has("name")) {
+        val nameValue = node.get("name").asText()
+        if (nameValue != null && nameValue.nonEmpty) {
+          Option(new LocalObjectReference(Option(nameValue)))
+        } else {
+          None
+        }
+      } else {
+        None
+      }
+
+      // Create a new SecretKeySelector with the extracted fields
+      new SecretKeySelector(localObjectRef, key)
     }
   }
 

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoader.scala
@@ -76,7 +76,7 @@ private[spark] object JobTemplateLoader {
   }
 
   /** Custom deserializer for SecretKeySelector objects. Handles the case where the
-    * localObjectReference (name field) is elided.
+    * localObjectReference is elided.
     */
   private class SecretKeySelectorDeserializer extends JsonDeserializer[SecretKeySelector] {
     @throws(classOf[JsonProcessingException])
@@ -87,7 +87,7 @@ private[spark] object JobTemplateLoader {
       // Extract the key field
       val key = Option(node.get("key")).map(_.asText())
 
-      // Extract the name field (which might be elided)
+      // Extract the localObjectReference (which might be elided)
       val localObjectRef = Option(node.get("name"))
         .filter(n => Option(n.asText()).exists(_.nonEmpty))
         .map(n => new LocalObjectReference(Option(n.asText())))

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
@@ -307,7 +307,7 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
 
   test("should correctly deserialize SecretKeySelector with elided LocalObjectReference ") {
     val secretName = "secretName"
-    val secretKey = "secretKey"
+    val secretKey  = "secretKey"
     val yamlWithCompleteSecretKeySelector =
       s"""priority: 1.0
         |namespace: default
@@ -327,10 +327,10 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
     val completeResult = JobTemplateLoader.loadJobItemTemplate(completeFile.getAbsolutePath)
 
     val secretKeyRef = for {
-      podSpec <- completeResult.podSpec
-      container <- podSpec.containers.headOption
-      env <- container.env.headOption
-      valueFrom <- env.valueFrom
+      podSpec      <- completeResult.podSpec
+      container    <- podSpec.containers.headOption
+      env          <- container.env.headOption
+      valueFrom    <- env.valueFrom
       secretKeyRef <- valueFrom.secretKeyRef
     } yield secretKeyRef
 

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
@@ -18,7 +18,7 @@
 package org.apache.spark.deploy.armada.submit
 
 import api.submit.{JobSubmitRequest, JobSubmitRequestItem}
-import k8s.io.api.core.v1.generated.PodSpec
+import k8s.io.api.core.v1.generated.{PodSpec, SecretKeySelector}
 import k8s.io.apimachinery.pkg.api.resource.generated.Quantity
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
@@ -303,5 +303,109 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
     resources.limits("cpu").getString shouldBe expectedLimitCpu
     resources.limits("memory").getString shouldBe expectedLimitMemory
     resources.limits("nvidia.com/gpu").getString shouldBe expectedLimitGpu
+  }
+
+  test("should correctly deserialize SecretKeySelector values") {
+    // Test case 1: Complete SecretKeySelector with both name and key
+    val yamlWithCompleteSecretKeySelector =
+      """priority: 1.0
+        |namespace: default
+        |podSpec:
+        |  containers:
+        |    - name: test-container
+        |      env:
+        |        - name: SECRET_ENV
+        |          valueFrom:
+        |            secretKeyRef:
+        |              name: my-secret
+        |              key: secret-key
+        |""".stripMargin
+
+    val completeFile = createTemplateFile("complete-secret-key-selector.yaml", yamlWithCompleteSecretKeySelector)
+    // This should not throw an exception
+    val completeResult = JobTemplateLoader.loadJobItemTemplate(completeFile.getAbsolutePath)
+
+    // Verify the pod spec was parsed correctly
+    completeResult.podSpec should not be empty
+    completeResult.podSpec.get.containers should have size 1
+    completeResult.podSpec.get.containers.head.env should have size 1
+    completeResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
+    completeResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
+
+    // Test case 2: SecretKeySelector with elided name field
+    val yamlWithElidedName =
+      """priority: 1.0
+        |namespace: default
+        |podSpec:
+        |  containers:
+        |    - name: test-container
+        |      env:
+        |        - name: SECRET_ENV
+        |          valueFrom:
+        |            secretKeyRef:
+        |              key: secret-key
+        |""".stripMargin
+
+    val elidedNameFile = createTemplateFile("elided-name-secret-key-selector.yaml", yamlWithElidedName)
+    // This should not throw an exception
+    val elidedNameResult = JobTemplateLoader.loadJobItemTemplate(elidedNameFile.getAbsolutePath)
+
+    // Verify the pod spec was parsed correctly
+    elidedNameResult.podSpec should not be empty
+    elidedNameResult.podSpec.get.containers should have size 1
+    elidedNameResult.podSpec.get.containers.head.env should have size 1
+    elidedNameResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
+    elidedNameResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
+
+    // Test case 3: SecretKeySelector with empty name field
+    val yamlWithEmptyName =
+      """priority: 1.0
+        |namespace: default
+        |podSpec:
+        |  containers:
+        |    - name: test-container
+        |      env:
+        |        - name: SECRET_ENV
+        |          valueFrom:
+        |            secretKeyRef:
+        |              name: ""
+        |              key: secret-key
+        |""".stripMargin
+
+    val emptyNameFile = createTemplateFile("empty-name-secret-key-selector.yaml", yamlWithEmptyName)
+    // This should not throw an exception
+    val emptyNameResult = JobTemplateLoader.loadJobItemTemplate(emptyNameFile.getAbsolutePath)
+
+    // Verify the pod spec was parsed correctly
+    emptyNameResult.podSpec should not be empty
+    emptyNameResult.podSpec.get.containers should have size 1
+    emptyNameResult.podSpec.get.containers.head.env should have size 1
+    emptyNameResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
+    emptyNameResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
+
+    // Test case 4: SecretKeySelector with missing key field
+    val yamlWithMissingKey =
+      """priority: 1.0
+        |namespace: default
+        |podSpec:
+        |  containers:
+        |    - name: test-container
+        |      env:
+        |        - name: SECRET_ENV
+        |          valueFrom:
+        |            secretKeyRef:
+        |              name: my-secret
+        |""".stripMargin
+
+    val missingKeyFile = createTemplateFile("missing-key-secret-key-selector.yaml", yamlWithMissingKey)
+    // This should not throw an exception
+    val missingKeyResult = JobTemplateLoader.loadJobItemTemplate(missingKeyFile.getAbsolutePath)
+
+    // Verify the pod spec was parsed correctly
+    missingKeyResult.podSpec should not be empty
+    missingKeyResult.podSpec.get.containers should have size 1
+    missingKeyResult.podSpec.get.containers.head.env should have size 1
+    missingKeyResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
+    missingKeyResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
   }
 }

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
@@ -321,7 +321,8 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
         |              key: secret-key
         |""".stripMargin
 
-    val completeFile = createTemplateFile("complete-secret-key-selector.yaml", yamlWithCompleteSecretKeySelector)
+    val completeFile =
+      createTemplateFile("complete-secret-key-selector.yaml", yamlWithCompleteSecretKeySelector)
     // This should not throw an exception
     val completeResult = JobTemplateLoader.loadJobItemTemplate(completeFile.getAbsolutePath)
 
@@ -346,7 +347,8 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
         |              key: secret-key
         |""".stripMargin
 
-    val elidedNameFile = createTemplateFile("elided-name-secret-key-selector.yaml", yamlWithElidedName)
+    val elidedNameFile =
+      createTemplateFile("elided-name-secret-key-selector.yaml", yamlWithElidedName)
     // This should not throw an exception
     val elidedNameResult = JobTemplateLoader.loadJobItemTemplate(elidedNameFile.getAbsolutePath)
 
@@ -397,7 +399,8 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
         |              name: my-secret
         |""".stripMargin
 
-    val missingKeyFile = createTemplateFile("missing-key-secret-key-selector.yaml", yamlWithMissingKey)
+    val missingKeyFile =
+      createTemplateFile("missing-key-secret-key-selector.yaml", yamlWithMissingKey)
     // This should not throw an exception
     val missingKeyResult = JobTemplateLoader.loadJobItemTemplate(missingKeyFile.getAbsolutePath)
 

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/JobTemplateLoaderSuite.scala
@@ -306,7 +306,8 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
   }
 
   test("should correctly deserialize SecretKeySelector values") {
-    // Test case 1: Complete SecretKeySelector with both name and key
+    val secretName = "secretName"
+    val secretKey = "secretKey"
     val yamlWithCompleteSecretKeySelector =
       """priority: 1.0
         |namespace: default
@@ -327,88 +328,8 @@ class JobTemplateLoaderSuite extends AnyFunSuite with BeforeAndAfter with Matche
     val completeResult = JobTemplateLoader.loadJobItemTemplate(completeFile.getAbsolutePath)
 
     // Verify the pod spec was parsed correctly
-    completeResult.podSpec should not be empty
-    completeResult.podSpec.get.containers should have size 1
-    completeResult.podSpec.get.containers.head.env should have size 1
-    completeResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
-    completeResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
-
-    // Test case 2: SecretKeySelector with elided name field
-    val yamlWithElidedName =
-      """priority: 1.0
-        |namespace: default
-        |podSpec:
-        |  containers:
-        |    - name: test-container
-        |      env:
-        |        - name: SECRET_ENV
-        |          valueFrom:
-        |            secretKeyRef:
-        |              key: secret-key
-        |""".stripMargin
-
-    val elidedNameFile =
-      createTemplateFile("elided-name-secret-key-selector.yaml", yamlWithElidedName)
-    // This should not throw an exception
-    val elidedNameResult = JobTemplateLoader.loadJobItemTemplate(elidedNameFile.getAbsolutePath)
-
-    // Verify the pod spec was parsed correctly
-    elidedNameResult.podSpec should not be empty
-    elidedNameResult.podSpec.get.containers should have size 1
-    elidedNameResult.podSpec.get.containers.head.env should have size 1
-    elidedNameResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
-    elidedNameResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
-
-    // Test case 3: SecretKeySelector with empty name field
-    val yamlWithEmptyName =
-      """priority: 1.0
-        |namespace: default
-        |podSpec:
-        |  containers:
-        |    - name: test-container
-        |      env:
-        |        - name: SECRET_ENV
-        |          valueFrom:
-        |            secretKeyRef:
-        |              name: ""
-        |              key: secret-key
-        |""".stripMargin
-
-    val emptyNameFile = createTemplateFile("empty-name-secret-key-selector.yaml", yamlWithEmptyName)
-    // This should not throw an exception
-    val emptyNameResult = JobTemplateLoader.loadJobItemTemplate(emptyNameFile.getAbsolutePath)
-
-    // Verify the pod spec was parsed correctly
-    emptyNameResult.podSpec should not be empty
-    emptyNameResult.podSpec.get.containers should have size 1
-    emptyNameResult.podSpec.get.containers.head.env should have size 1
-    emptyNameResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
-    emptyNameResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
-
-    // Test case 4: SecretKeySelector with missing key field
-    val yamlWithMissingKey =
-      """priority: 1.0
-        |namespace: default
-        |podSpec:
-        |  containers:
-        |    - name: test-container
-        |      env:
-        |        - name: SECRET_ENV
-        |          valueFrom:
-        |            secretKeyRef:
-        |              name: my-secret
-        |""".stripMargin
-
-    val missingKeyFile =
-      createTemplateFile("missing-key-secret-key-selector.yaml", yamlWithMissingKey)
-    // This should not throw an exception
-    val missingKeyResult = JobTemplateLoader.loadJobItemTemplate(missingKeyFile.getAbsolutePath)
-
-    // Verify the pod spec was parsed correctly
-    missingKeyResult.podSpec should not be empty
-    missingKeyResult.podSpec.get.containers should have size 1
-    missingKeyResult.podSpec.get.containers.head.env should have size 1
-    missingKeyResult.podSpec.get.containers.head.env.head.valueFrom should not be empty
-    missingKeyResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef should not be empty
+    val secretKeyRef = completeResult.podSpec.get.containers.head.env.head.valueFrom.get.secretKeyRef.get
+    secretKeyRef.getLocalObjectReference.getName shouldBe "my-secret"
+    secretKeyRef.getKey shouldBe "secret-key"
   }
 }


### PR DESCRIPTION
In order to support s3 keys, this PR adds a custom SecretKeySelectorDeserializer that handles yaml with the localObjectReference reference elided.

Also some minor cleanup:
1. Removes the auth token from the job so it doesn't appear in the lookout ui.
2. Added a mechanism to add extra jars to the classpath/image, (for the aws/s3 jars.)
3. Validates the config file name.
