### PR TITLE
Use spark connect to submit jobs in armada.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -76,6 +76,9 @@ project/**/metals.sbt
 # don't check in your config file
 scripts/config.sh
 
+# benchmark kubeconfig
+benchmark/kubeconfig
+
 dependency-reduced-pom.xml
 .spark-*
 scripts/armadactl

--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,9 @@ scripts/config.sh
 *.key
 *.pem
 
+# benchmark kubeconfig
+benchmark/kubeconfig
+
 dependency-reduced-pom.xml
 .spark-*
 scripts/armadactl

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It provides preconfigured Docker images, tooling for efficient image management,
 
 - **Java** 11 or 17
 - **Apache Maven** 3.9.6+
-- _(Optional)_ [kind](https://kind.sigs.k8s.io/) for local clusters
+- *(Optional)* [kind](https://kind.sigs.k8s.io/) for local clusters
 - An accessible Armada server and Lookout endpoint — see the [Armada Operator Quickstart](https://github.com/armadaproject/armada-operator) to set one up
 
 ### Build
@@ -31,17 +31,21 @@ mvn clean package
 
 ### Supported Version Matrix
 
-| Spark   | Scala  | Java |
-|---------|--------|------|
-| 3.5.5   | 2.12.18 | 17  |
-| 3.5.5   | 2.13.8  | 17  |
+
+| Spark | Scala   | Java |
+| ----- | ------- | ---- |
+| 3.5.5 | 2.12.18 | 17   |
+| 3.5.5 | 2.13.8  | 17   |
+
 
 ### Planned Future Version Support
 
-| Spark   | Scala  | Java |
-|---------|--------|------|
-| 3.3.4   | 2.12.15 | 11  |
-| 3.3.4   | 2.13.8  | 11  |
+
+| Spark | Scala   | Java |
+| ----- | ------- | ---- |
+| 3.3.4 | 2.12.15 | 11   |
+| 3.3.4 | 2.13.8  | 11   |
+
 
 ### Build Docker Images
 
@@ -49,14 +53,16 @@ mvn clean package
 ./scripts/createImage.sh [-i image-name] [-m armada-master-url] [-q armada-queue] [-l armada-lookout-url]
 ```
 
+
 | Flag | Description        | Example                    |
-|------|--------------------|----------------------------|
+| ---- | ------------------ | -------------------------- |
 | `-i` | Docker image name  | `spark:armada`             |
 | `-m` | Armada master URL  | `armada://localhost:30002` |
 | `-q` | Armada queue       | `default`                  |
 | `-l` | Armada Lookout URL | `http://localhost:30000`   |
 | `-p` | Include Python     |                            |
 | `-h` | Display help       |                            |
+
 
 You can store defaults in `scripts/config.sh`:
 
@@ -85,48 +91,47 @@ kind load docker-image $IMAGE_NAME --name armada
 ```
 
 ### Running a remote Armada server using Armada Operator
+
 The default Armada Operator setup allows only localhost access.  You can quickly set up a local Armada server
 configured to allow external access from other hosts, useful for client development and testing. For this
 configuration:
 
 - Copy the file `e2e/kind-config-external-access.yaml` in this repository to `hack/kind-config.yaml`
 in your `armada-operator` repository.
-
 - Edit the newly-copied `hack/kind-config.yaml` as noted in the beginning comments of that file.
-
 - Run the armada-operator setup commands (usually `make kind-all`) to create and start your Armada instance.
-
 - Copy the `$HOME/.kube/config` and `$HOME/.armadactl.yaml` (that Armada Operator will generate) from the Armada
 server host to your `$HOME` directory on the client (local) host. Then edit the local `.kube/config` and on
 the line that has `server: https://0.0.0.0:6443`, change the `0.0.0.0` address to the IP address or hostname
 of the remote Armada server system.
-
 - Generate a copy of the client TLS key, cert, and CA-cert files: (1) go into the `e2e` subdirectory, and
 run `./extract-kind-cert.sh` - it will generate `client.crt`, `client.key`, and `ca.crt`, from the output
 of `kubectl config view`. These files can be left in this directory.
-
 - Copy the `$HOME/.armadactl.yaml` from the Armada server host to your home directory on your client system.
-
 - You should then be able to run `kubectl get pods -A` and see a list of the running pods on the remote
 Armada server, as well as running `armadactl get queues`.
-
 - Verify the functionality of your setup by editing `scripts/config.sh` and changing the following line:
+
 ```
 ARMADA_MASTER=armada://192.168.12.135:30002
 ```
+
 to the IP address or hostname of your Armada server. You should not need to change the port number.
 
 Also, set the location of the three TLS certificate files by adding/setting:
+
 ```
 export CLIENT_CERT_FILE=e2e/client.crt
 export CLIENT_KEY_FILE=e2e/client.key
 export CLUSTER_CA_FILE=e2e/ca.crt
 ```
 
--  You should be able to now verify the armada-spark configuration by running the E2E tests:
+- You should be able to now verify the armada-spark configuration by running the E2E tests:
+
 ```
 $ ./scripts/dev-e2e.sh
 ```
+
 This will save its output to `e2e-test.log` for further debugging.
 
 ---
@@ -148,6 +153,7 @@ To run the E2E tests, run Armada using the [Operator Quickstart](https://github.
 ```bash
 scripts/test-e2e.sh
 ```
+
 ### Linting
 
 To check the code for linting issues, use the following command:
@@ -197,6 +203,18 @@ The Docker image includes Jupyter support (requires `INCLUDE_PYTHON=true`):
 ```
 
 Opens at `http://localhost:8888`. Override the port with `JUPYTER_PORT` in `scripts/config.sh`. Example notebooks from `example/jupyter/notebooks` are mounted at `/home/spark/workspace/notebooks`.
+
+#### Spark Connect
+
+Pass `-C` to run in Spark Connect mode (experimental). The Spark Connect server runs in the cluster (Armada cluster mode) and Jupyter connects to it as a thin gRPC client:
+
+```bash
+./scripts/runJupyter.sh -C
+```
+
+Use `kubectl port-forward` command for the connect port (`15002`). Allocation follows `-A static|dynamic` (default dynamic); in static mode set `EXECUTOR_INSTANCES` to choose the executor count. 
+
+See [`spark_connect_demo.ipynb`](example/jupyter/notebooks/spark_connect_demo.ipynb).
 
 ### Spark History Server
 
@@ -265,3 +283,4 @@ mvn spotless:check       # Check formatting
 mvn spotless:apply       # Auto-fix formatting
 scripts/dev-e2e.sh       # Run E2E tests (requires a running Armada cluster)
 ```
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -46,7 +46,12 @@ RUN if [ "$include_python" = "true" ]; then \
             jupyter \
             notebook \
             ipykernel \
-            pyspark==${spark_version} && \
+            pyspark==${spark_version} \
+            pandas \
+            pyarrow \
+            grpcio \
+            grpcio-status \
+            protobuf && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*; \
     fi

--- a/example/jupyter/notebooks/spark_connect_demo.ipynb
+++ b/example/jupyter/notebooks/spark_connect_demo.ipynb
@@ -1,0 +1,124 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dbda5592",
+   "metadata": {},
+   "source": [
+    "# Spark Connect + Armada Demo\n",
+    "\n",
+    "**Architecture:**\n",
+    "- Spark driver + Connect server run **in the cluster** (Armada cluster mode)\n",
+    "- This notebook is a **thin gRPC client** - no JVM locally\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "```bash\n",
+    "./scripts/runJupyter.sh -C\n",
+    "kubectl port-forward <driver-pod> 15002:15002\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# Use host.docker.internal when running Jupyter in Docker (bridge network)\n",
+    "# Use localhost if running Jupyter directly on your machine\n",
+    "CONNECT_URL = \"sc://host.docker.internal:15002\"\n",
+    "\n",
+    "spark = SparkSession.builder.remote(CONNECT_URL).getOrCreate()\n",
+    "print(f\"Connected! Spark version: {spark.version}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(\"SELECT 'Hello from Spark Connect on Armada!' as message\").show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dynamic Allocation Test\n",
+    "\n",
+    "200 partitions with 10s delay each to trigger executor scale-up.\n",
+    "\n",
+    "Watch with: `kubectl get pods -n default -w`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "num_partitions = 200\n",
+    "\n",
+    "print(f\"Running Spark Pi with {num_partitions} slow partitions...\")\n",
+    "\n",
+    "def slow_pi_partition(iterator):\n",
+    "    import pandas as pd\n",
+    "    import time\n",
+    "    import random\n",
+    "    for pdf in iterator:\n",
+    "        time.sleep(10)\n",
+    "        count = 0\n",
+    "        total = len(pdf)\n",
+    "        for _ in range(total):\n",
+    "            x, y = random.random(), random.random()\n",
+    "            if x * x + y * y < 1:\n",
+    "                count += 1\n",
+    "        yield pd.DataFrame({\"count\": [count], \"total\": [total]})\n",
+    "\n",
+    "start = time.time()\n",
+    "\n",
+    "df_input = spark.range(0, 1000000, numPartitions=num_partitions)\n",
+    "df_result = df_input.mapInPandas(slow_pi_partition, schema=\"count long, total long\")\n",
+    "totals = df_result.agg(\n",
+    "    F.sum(\"count\").alias(\"count\"),\n",
+    "    F.sum(\"total\").alias(\"total\")\n",
+    ").collect()\n",
+    "\n",
+    "pi = 4.0 * totals[0][\"count\"] / totals[0][\"total\"]\n",
+    "elapsed = time.time() - start\n",
+    "\n",
+    "print(f\"Pi is approximately: {pi}\")\n",
+    "print(f\"Completed in {elapsed:.1f}s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.stop()\n",
+    "print(\"Disconnected\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/example/jupyter/notebooks/spark_connect_demo.ipynb
+++ b/example/jupyter/notebooks/spark_connect_demo.ipynb
@@ -4,7 +4,19 @@
    "cell_type": "markdown",
    "id": "dbda5592",
    "metadata": {},
-   "source": "# Spark Connect + Armada Demo\n\n**Architecture:**\n- Spark driver + Connect server run **in the cluster** (Armada cluster mode)\n- This notebook is a **thin gRPC client** - no JVM locally\n\n**Prerequisites:**\n```bash\n./scripts/runJupyter.sh -C\nkubectl port-forward -n default $(kubectl get pod -n default -l spark-role=driver,spark-app-name=spark-connect-server -o name | head -1) 15002:15002\n```"
+   "source": [
+    "# Spark Connect + Armada Demo\n",
+    "\n",
+    "**Architecture:**\n",
+    "- Spark driver + Connect server run **in the cluster** (Armada cluster mode)\n",
+    "- This notebook is a **thin gRPC client** - no JVM locally\n",
+    "\n",
+    "**Prerequisites:**\n",
+    "```bash\n",
+    "./scripts/runJupyter.sh -C\n",
+    "kubectl port-forward -n default $(kubectl get pod -n default -l spark-role=driver,spark-app-name=spark-connect-server -o name | head -1) 15002:15002\n",
+    "```"
+   ]
   },
   {
    "cell_type": "code",

--- a/example/jupyter/notebooks/spark_connect_demo.ipynb
+++ b/example/jupyter/notebooks/spark_connect_demo.ipynb
@@ -1,0 +1,112 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "dbda5592",
+   "metadata": {},
+   "source": "# Spark Connect + Armada Demo\n\n**Architecture:**\n- Spark driver + Connect server run **in the cluster** (Armada cluster mode)\n- This notebook is a **thin gRPC client** - no JVM locally\n\n**Prerequisites:**\n```bash\n./scripts/runJupyter.sh -C\nkubectl port-forward -n default $(kubectl get pod -n default -l spark-role=driver,spark-app-name=spark-connect-server -o name | head -1) 15002:15002\n```"
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql import SparkSession\n",
+    "from pyspark.sql import functions as F\n",
+    "\n",
+    "# Use host.docker.internal when running Jupyter in Docker (bridge network)\n",
+    "# Use localhost if running Jupyter directly on your machine\n",
+    "CONNECT_URL = \"sc://host.docker.internal:15002\"\n",
+    "\n",
+    "spark = SparkSession.builder.remote(CONNECT_URL).getOrCreate()\n",
+    "print(f\"Connected! Spark version: {spark.version}\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.sql(\"SELECT 'Hello from Spark Connect on Armada!' as message\").show(truncate=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Dynamic Allocation Test\n",
+    "\n",
+    "200 partitions with 10s delay each to trigger executor scale-up.\n",
+    "\n",
+    "Watch with: `kubectl get pods -n default -w`"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import time\n",
+    "\n",
+    "num_partitions = 200\n",
+    "\n",
+    "print(f\"Running Spark Pi with {num_partitions} slow partitions...\")\n",
+    "\n",
+    "def slow_pi_partition(iterator):\n",
+    "    import pandas as pd\n",
+    "    import time\n",
+    "    import random\n",
+    "    for pdf in iterator:\n",
+    "        time.sleep(10)\n",
+    "        count = 0\n",
+    "        total = len(pdf)\n",
+    "        for _ in range(total):\n",
+    "            x, y = random.random(), random.random()\n",
+    "            if x * x + y * y < 1:\n",
+    "                count += 1\n",
+    "        yield pd.DataFrame({\"count\": [count], \"total\": [total]})\n",
+    "\n",
+    "start = time.time()\n",
+    "\n",
+    "df_input = spark.range(0, 1000000, numPartitions=num_partitions)\n",
+    "df_result = df_input.mapInPandas(slow_pi_partition, schema=\"count long, total long\")\n",
+    "totals = df_result.agg(\n",
+    "    F.sum(\"count\").alias(\"count\"),\n",
+    "    F.sum(\"total\").alias(\"total\")\n",
+    ").collect()\n",
+    "\n",
+    "pi = 4.0 * totals[0][\"count\"] / totals[0][\"total\"]\n",
+    "elapsed = time.time() - start\n",
+    "\n",
+    "print(f\"Pi is approximately: {pi}\")\n",
+    "print(f\"Completed in {elapsed:.1f}s\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "spark.stop()\n",
+    "print(\"Disconnected\")"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.10.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/scripts/runJupyter.sh
+++ b/scripts/runJupyter.sh
@@ -1,20 +1,54 @@
 #!/bin/bash
 set -euo pipefail
 
+# Parse -C (Spark Connect) flag before sourcing init.sh
+USE_SPARK_CONNECT=false
+for arg in "$@"; do
+    if [ "$arg" = "-C" ]; then
+        USE_SPARK_CONNECT=true
+        break
+    fi
+done
+# Remove -C from args so init.sh doesn't see it
+filtered_args=()
+for arg in "$@"; do
+    if [ "$arg" != "-C" ]; then
+        filtered_args+=("$arg")
+    fi
+done
+set -- "${filtered_args[@]+"${filtered_args[@]}"}"
+
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    # Spark Connect mode: driver runs in cluster, Jupyter is a thin gRPC client
+    export DEPLOY_MODE=cluster
+    export ALLOCATION_MODE=dynamic
+else
+    # Client mode: driver runs inside the Jupyter container
+    export DEPLOY_MODE="${DEPLOY_MODE:-client}"
+fi
+
 # init environment variables
 scripts="$(cd "$(dirname "$0")"; pwd)"
+root="$(cd "$scripts/.."; pwd)"
 source "$scripts/init.sh"
 
 # Jupyter-specific defaults
 JUPYTER_PORT="${JUPYTER_PORT:-8888}"
+CONNECT_PORT="${CONNECT_PORT:-15002}"
 SPARK_BLOCK_MANAGER_PORT="${SPARK_BLOCK_MANAGER_PORT:-10061}"
 SPARK_DRIVER_PORT="${SPARK_DRIVER_PORT:-7078}"
 
-# SPARK_DRIVER_HOST is required - must be reachable from Kubernetes executors
-if [ -z "${SPARK_DRIVER_HOST:-}" ]; then
-    echo "Error: SPARK_DRIVER_HOST must be set."
-    echo ""
-    exit 1
+# Memory limits (shared with submitArmadaSpark.sh)
+EXECUTOR_MEMORY_LIMIT="${EXECUTOR_MEMORY_LIMIT:-1Gi}"
+DRIVER_MEMORY_LIMIT="${DRIVER_MEMORY_LIMIT:-1Gi}"
+
+if [ "$USE_SPARK_CONNECT" = false ]; then
+    # SPARK_DRIVER_HOST is required - must be reachable from Kubernetes executors
+    if [ -z "${SPARK_DRIVER_HOST:-}" ]; then
+        echo "Error: SPARK_DRIVER_HOST must be set."
+        echo ""
+        exit 1
+    fi
 fi
 
 if [ "${USE_KIND}" == "true" ]; then
@@ -31,7 +65,6 @@ if [ "${USE_KIND}" == "true" ]; then
 fi
 
 # Setup workspace directory
-root="$(cd "$scripts/.."; pwd)"
 notebooks_dir="$root/example/jupyter/notebooks"
 workspace_dir="$root/example/jupyter/workspace"
 
@@ -50,34 +83,138 @@ if [ -d "$notebooks_dir" ]; then
     done
 fi
 
+# ── Spark Connect: submit driver + executors to Armada ──
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    CONNECT_JAR_NAME="spark-connect_${SCALA_BIN_VERSION}-${SPARK_VERSION}.jar"
+    CONNECT_JAR_LOCAL="$root/extraJars/$CONNECT_JAR_NAME"
+    CONNECT_JAR_REMOTE="local:///opt/spark/jars/$CONNECT_JAR_NAME"
+    MAVEN_URL="https://repo1.maven.org/maven2/org/apache/spark/spark-connect_${SCALA_BIN_VERSION}/${SPARK_VERSION}/${CONNECT_JAR_NAME}"
+
+    if [ ! -f "$CONNECT_JAR_LOCAL" ]; then
+        echo "spark-connect JAR not found in extraJars/. Downloading..."
+        if ! curl -sfL -o "$CONNECT_JAR_LOCAL" "$MAVEN_URL"; then
+            echo "Error: Failed to download $CONNECT_JAR_NAME"
+            rm -f "$CONNECT_JAR_LOCAL"
+            exit 1
+        fi
+        echo "Downloaded $CONNECT_JAR_NAME"
+        echo ">>> Rebuild the image: ./scripts/createImage.sh"
+        exit 0
+    fi
+
+    echo "Submitting Spark Connect server to Armada (cluster mode)..."
+
+    # Build spark-submit args (same pattern as submitArmadaSpark.sh)
+    SPARK_SUBMIT_ARGS=(
+        --master $ARMADA_MASTER
+        --deploy-mode cluster
+        --name spark-connect-server
+        --class org.apache.spark.sql.connect.service.SparkConnectServer
+        ${S3_CONF[@]+"${S3_CONF[@]}"}
+        --conf spark.connect.grpc.binding.port=$CONNECT_PORT
+        --conf spark.home=/opt/spark
+        --conf spark.armada.container.image=$IMAGE_NAME
+        --conf spark.armada.queue=$ARMADA_QUEUE
+        --conf spark.armada.lookouturl=${ARMADA_LOOKOUT_URL:-http://localhost:30000}
+        --conf spark.armada.scheduling.namespace=${ARMADA_NAMESPACE:-default}
+        --conf spark.armada.scheduling.nodeUniformity=${ARMADA_NODE_UNIFORMITY_LABEL:-armada-spark}
+        --conf spark.armada.executor.limit.memory=$EXECUTOR_MEMORY_LIMIT
+        --conf spark.armada.executor.request.memory=$EXECUTOR_MEMORY_LIMIT
+        --conf spark.armada.driver.limit.memory=$DRIVER_MEMORY_LIMIT
+        --conf spark.armada.driver.request.memory=$DRIVER_MEMORY_LIMIT
+        --conf spark.kubernetes.executor.disableConfigMap=true
+        --conf spark.local.dir=/tmp
+        --conf spark.jars.ivy=/tmp/.ivy
+        --conf spark.dynamicAllocation.enabled=true
+        --conf spark.dynamicAllocation.minExecutors=0
+        --conf spark.dynamicAllocation.maxExecutors=5
+        --conf spark.dynamicAllocation.executorIdleTimeout=60
+        --conf spark.dynamicAllocation.schedulerBacklogTimeout=5
+        --conf spark.dynamicAllocation.initialExecutors=1
+        --conf spark.dynamicAllocation.shuffleTracking.enabled=false
+        --conf spark.decommission.enabled=true
+        --conf spark.storage.decommission.enabled=true
+        --conf spark.storage.decommission.shuffleBlocks.enabled=true
+    )
+
+    # Add deploy mode args (internalUrl for cluster mode)
+    SPARK_SUBMIT_ARGS+=(${DEPLOY_MODE_ARGS[@]+"${DEPLOY_MODE_ARGS[@]}"})
+
+    # Add auth args
+    SPARK_SUBMIT_ARGS+=(${ARMADA_AUTH_ARGS[@]+"${ARMADA_AUTH_ARGS[@]}"})
+
+    # Add event log conf
+    SPARK_SUBMIT_ARGS+=(${EVENT_LOG_CONF[@]+"${EVENT_LOG_CONF[@]}"})
+
+    # Add primary resource
+    SPARK_SUBMIT_ARGS+=($CONNECT_JAR_REMOTE)
+
+    # Cluster-mode submit: submits the job and exits (non-zero exit is OK).
+    # Tee the output so we can detect whether a driver job was actually submitted.
+    SUBMIT_LOG=$(mktemp)
+    docker run \
+      --rm --network host \
+      "${DOCKER_ENV_ARGS[@]}" \
+      $IMAGE_NAME \
+      /opt/spark/bin/spark-submit "${SPARK_SUBMIT_ARGS[@]}" 2>&1 | tee "$SUBMIT_LOG" || true
+
+    echo ""
+    if grep -q "Submitted driver job with ID" "$SUBMIT_LOG"; then
+        DRIVER_JOB_ID=$(grep "Submitted driver job with ID" "$SUBMIT_LOG" | tail -1 | sed -E 's/.*ID: ([^,]+).*/\1/')
+        echo ">>> Spark Connect server submitted (Armada driver job: $DRIVER_JOB_ID)"
+    else
+        echo ">>> WARNING: No driver job ID found in submit output."
+        echo ">>> The Spark Connect server may not have started. Review the log above and check:"
+        echo ">>>   ${ARMADA_LOOKOUT_URL:-http://localhost:30000}"
+    fi
+    rm -f "$SUBMIT_LOG"
+    echo ""
+    echo "Port-forward to the driver pod before using Jupyter:"
+    echo "  kubectl port-forward \$(kubectl get pods -n default -o name | head -1) $CONNECT_PORT:$CONNECT_PORT"
+    echo ""
+fi
+
+# ── Start Jupyter container ──
+
 # Remove existing container if it exists
 if docker ps -a --format '{{.Names}}' | grep -q "^armada-jupyter$"; then
     echo "Removing existing armada-jupyter container..."
     docker rm -f armada-jupyter >/dev/null 2>&1 || true
 fi
 
-# Run Jupyter container
-docker run -d \
-  --name armada-jupyter \
-  -p ${JUPYTER_PORT}:8888 \
-  -p ${SPARK_BLOCK_MANAGER_PORT}:${SPARK_BLOCK_MANAGER_PORT} \
-  -p ${SPARK_DRIVER_PORT}:${SPARK_DRIVER_PORT} \
-  -e SPARK_DRIVER_HOST=${SPARK_DRIVER_HOST} \
-  -e SPARK_DRIVER_PORT=${SPARK_DRIVER_PORT} \
-  -e SPARK_BLOCK_MANAGER_PORT=${SPARK_BLOCK_MANAGER_PORT} \
-  -e ARMADA_MASTER=${ARMADA_MASTER} \
-  -e ARMADA_QUEUE=${ARMADA_QUEUE} \
-  -e ARMADA_NAMESPACE=${ARMADA_NAMESPACE:-default} \
-  -e IMAGE_NAME=${IMAGE_NAME} \
-  -e ARMADA_AUTH_TOKEN=${ARMADA_AUTH_TOKEN:-} \
-  -e ARMADA_AUTH_SCRIPT_PATH=${ARMADA_AUTH_SCRIPT_PATH:-} \
-  -e ARMADA_EVENT_WATCHER_USE_TLS=${ARMADA_EVENT_WATCHER_USE_TLS:-false} \
-  -e ARMADA_NODE_UNIFORMITY_LABEL=${ARMADA_NODE_UNIFORMITY_LABEL:-armada-spark} \
-  -v "$workspace_dir:/home/spark/workspace" \
-  -v "$root/conf:/opt/spark/conf:ro" \
-  --rm \
-  ${IMAGE_NAME} \
-  /opt/spark/bin/jupyter-entrypoint.sh
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    # Spark Connect mode: thin client, no driver ports needed
+    docker run -d \
+      --name armada-jupyter \
+      -p ${JUPYTER_PORT}:8888 \
+      -v "$workspace_dir:/home/spark/workspace" \
+      --rm \
+      ${IMAGE_NAME} \
+      /opt/spark/bin/jupyter-entrypoint.sh
+else
+    # Client mode: driver runs inside, needs ports exposed
+    docker run -d \
+      --name armada-jupyter \
+      -p ${JUPYTER_PORT}:8888 \
+      -p ${SPARK_BLOCK_MANAGER_PORT}:${SPARK_BLOCK_MANAGER_PORT} \
+      -p ${SPARK_DRIVER_PORT}:${SPARK_DRIVER_PORT} \
+      -e SPARK_DRIVER_HOST=${SPARK_DRIVER_HOST} \
+      -e SPARK_DRIVER_PORT=${SPARK_DRIVER_PORT} \
+      -e SPARK_BLOCK_MANAGER_PORT=${SPARK_BLOCK_MANAGER_PORT} \
+      -e ARMADA_MASTER=${ARMADA_MASTER} \
+      -e ARMADA_QUEUE=${ARMADA_QUEUE} \
+      -e ARMADA_NAMESPACE=${ARMADA_NAMESPACE:-default} \
+      -e IMAGE_NAME=${IMAGE_NAME} \
+      -e ARMADA_AUTH_TOKEN=${ARMADA_AUTH_TOKEN:-} \
+      -e ARMADA_AUTH_SCRIPT_PATH=${ARMADA_AUTH_SCRIPT_PATH:-} \
+      -e ARMADA_EVENT_WATCHER_USE_TLS=${ARMADA_EVENT_WATCHER_USE_TLS:-false} \
+      -e ARMADA_NODE_UNIFORMITY_LABEL=${ARMADA_NODE_UNIFORMITY_LABEL:-armada-spark} \
+      -v "$workspace_dir:/home/spark/workspace" \
+      -v "$root/conf:/opt/spark/conf:ro" \
+      --rm \
+      ${IMAGE_NAME} \
+      /opt/spark/bin/jupyter-entrypoint.sh
+fi
 
 # Wait for Jupyter server to be reachable
 for i in {1..10}; do
@@ -85,6 +222,11 @@ for i in {1..10}; do
         echo "Jupyter notebook is running at http://localhost:${JUPYTER_PORT}"
         echo "Workspace is available in the container at /home/spark/workspace"
         echo "Notebooks are persisted in $workspace_dir"
+        if [ "$USE_SPARK_CONNECT" = true ]; then
+            echo ""
+            echo "Using Spark Connect mode."
+            echo "Connect in notebook with: SparkSession.builder.remote('sc://host.docker.internal:$CONNECT_PORT').getOrCreate()"
+        fi
         exit 0
     fi
     sleep 1

--- a/scripts/runJupyter.sh
+++ b/scripts/runJupyter.sh
@@ -105,26 +105,24 @@ if [ "$USE_SPARK_CONNECT" = true ]; then
 
     echo "Submitting Spark Connect server to Armada (cluster mode, $ALLOCATION_MODE allocation)..."
 
-    # Build spark-submit args (same pattern as submitArmadaSpark.sh)
+    # Build spark-submit args (same pattern as submitArmadaSpark.sh).
+    # ARMADA_COMMON_CONF (from init.sh) supplies spark.home, spark.local.dir,
+    # container image, queue, lookout URL, and disableConfigMap; only the
+    # connect-specific confs are listed explicitly here.
     SPARK_SUBMIT_ARGS=(
         --master $ARMADA_MASTER
         --deploy-mode cluster
         --name spark-connect-server
         --class org.apache.spark.sql.connect.service.SparkConnectServer
         ${S3_CONF[@]+"${S3_CONF[@]}"}
+        ${ARMADA_COMMON_CONF[@]+"${ARMADA_COMMON_CONF[@]}"}
         --conf spark.connect.grpc.binding.port=$CONNECT_PORT
-        --conf spark.home=/opt/spark
-        --conf spark.armada.container.image=$IMAGE_NAME
-        --conf spark.armada.queue=$ARMADA_QUEUE
-        --conf spark.armada.lookouturl=${ARMADA_LOOKOUT_URL:-http://localhost:30000}
         --conf spark.armada.scheduling.namespace=${ARMADA_NAMESPACE:-default}
         --conf spark.armada.scheduling.nodeUniformity=${ARMADA_NODE_UNIFORMITY_LABEL:-armada-spark}
         --conf spark.armada.executor.limit.memory=$EXECUTOR_MEMORY_LIMIT
         --conf spark.armada.executor.request.memory=$EXECUTOR_MEMORY_LIMIT
         --conf spark.armada.driver.limit.memory=$DRIVER_MEMORY_LIMIT
         --conf spark.armada.driver.request.memory=$DRIVER_MEMORY_LIMIT
-        --conf spark.kubernetes.executor.disableConfigMap=true
-        --conf spark.local.dir=/tmp
         --conf spark.jars.ivy=/tmp/.ivy
     )
 
@@ -163,12 +161,12 @@ if [ "$USE_SPARK_CONNECT" = true ]; then
     # Add primary resource
     SPARK_SUBMIT_ARGS+=($CONNECT_JAR_REMOTE)
 
-    # Cluster-mode submit: submits the job and exits (non-zero exit is OK)
+    # Cluster-mode submit: submits the driver + executor jobs to Armada and exits
     docker run \
       --rm --network host \
       "${DOCKER_ENV_ARGS[@]}" \
       $IMAGE_NAME \
-      /opt/spark/bin/spark-submit "${SPARK_SUBMIT_ARGS[@]}" || true
+      /opt/spark/bin/spark-submit "${SPARK_SUBMIT_ARGS[@]}"
 
     echo ""
     echo "Spark Connect server submitted."

--- a/scripts/runJupyter.sh
+++ b/scripts/runJupyter.sh
@@ -161,10 +161,11 @@ if [ "$USE_SPARK_CONNECT" = true ]; then
     # Add primary resource
     SPARK_SUBMIT_ARGS+=($CONNECT_JAR_REMOTE)
 
-    # Cluster-mode submit: submits the driver + executor jobs to Armada and exits
+    # Cluster-mode submit: submits the driver + executor jobs to Armada and exits.
     docker run \
       --rm --network host \
       "${DOCKER_ENV_ARGS[@]}" \
+      -v "$root/conf:/opt/spark/conf" \
       $IMAGE_NAME \
       /opt/spark/bin/spark-submit "${SPARK_SUBMIT_ARGS[@]}"
 

--- a/scripts/runJupyter.sh
+++ b/scripts/runJupyter.sh
@@ -1,23 +1,55 @@
 #!/bin/bash
 set -euo pipefail
 
+# Parse -C (Spark Connect) flag before sourcing init.sh
+USE_SPARK_CONNECT=false
+for arg in "$@"; do
+    if [ "$arg" = "-C" ]; then
+        USE_SPARK_CONNECT=true
+        break
+    fi
+done
+# Remove -C from args so init.sh doesn't see it
+filtered_args=()
+for arg in "$@"; do
+    if [ "$arg" != "-C" ]; then
+        filtered_args+=("$arg")
+    fi
+done
+set -- "${filtered_args[@]+"${filtered_args[@]}"}"
+
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    # Spark Connect mode: driver runs in cluster, Jupyter is a thin gRPC client.
+    # Allocation mode comes from -A (init.sh defaults it to dynamic); the connect
+    # submit below honors static vs dynamic when building spark-submit args.
+    export DEPLOY_MODE=cluster
+else
+    # Client mode: driver runs inside the Jupyter container
+    export DEPLOY_MODE="${DEPLOY_MODE:-client}"
+fi
+
 # init environment variables
 scripts="$(cd "$(dirname "$0")"; pwd)"
+root="$(cd "$scripts/.."; pwd)"
+source "$scripts/init.sh"
 
-# Jupyter always runs in client mode; set defaults before sourcing init.sh
-# so that DEPLOY_MODE_ARGS is built with the correct values.
-DEPLOY_MODE=client
+# Jupyter-specific defaults
 JUPYTER_PORT="${JUPYTER_PORT:-8888}"
+CONNECT_PORT="${CONNECT_PORT:-15002}"
 SPARK_BLOCK_MANAGER_PORT="${SPARK_BLOCK_MANAGER_PORT:-10061}"
 SPARK_DRIVER_PORT="${SPARK_DRIVER_PORT:-7078}"
 
-source "$scripts/init.sh"
+# Memory limits (shared with submitArmadaSpark.sh)
+EXECUTOR_MEMORY_LIMIT="${EXECUTOR_MEMORY_LIMIT:-1Gi}"
+DRIVER_MEMORY_LIMIT="${DRIVER_MEMORY_LIMIT:-1Gi}"
 
-# SPARK_DRIVER_HOST is required - must be reachable from Kubernetes executors
-if [ -z "${SPARK_DRIVER_HOST:-}" ]; then
-    echo "Error: SPARK_DRIVER_HOST must be set."
-    echo ""
-    exit 1
+if [ "$USE_SPARK_CONNECT" = false ]; then
+    # SPARK_DRIVER_HOST is required - must be reachable from Kubernetes executors
+    if [ -z "${SPARK_DRIVER_HOST:-}" ]; then
+        echo "Error: SPARK_DRIVER_HOST must be set."
+        echo ""
+        exit 1
+    fi
 fi
 
 if [ "${USE_KIND}" == "true" ]; then
@@ -34,7 +66,6 @@ if [ "${USE_KIND}" == "true" ]; then
 fi
 
 # Setup workspace directory
-root="$(cd "$scripts/.."; pwd)"
 notebooks_dir="$root/example/jupyter/notebooks"
 workspace_dir="$root/example/jupyter/workspace"
 
@@ -53,31 +84,138 @@ if [ -d "$notebooks_dir" ]; then
     done
 fi
 
+# ── Spark Connect: submit driver + executors to Armada ──
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    CONNECT_JAR_NAME="spark-connect_${SCALA_BIN_VERSION}-${SPARK_VERSION}.jar"
+    CONNECT_JAR_LOCAL="$root/extraJars/$CONNECT_JAR_NAME"
+    CONNECT_JAR_REMOTE="local:///opt/spark/jars/$CONNECT_JAR_NAME"
+    MAVEN_URL="https://repo1.maven.org/maven2/org/apache/spark/spark-connect_${SCALA_BIN_VERSION}/${SPARK_VERSION}/${CONNECT_JAR_NAME}"
+
+    if [ ! -f "$CONNECT_JAR_LOCAL" ]; then
+        echo "spark-connect JAR not found in extraJars/. Downloading..."
+        if ! curl -sfL -o "$CONNECT_JAR_LOCAL" "$MAVEN_URL"; then
+            echo "Error: Failed to download $CONNECT_JAR_NAME"
+            rm -f "$CONNECT_JAR_LOCAL"
+            exit 1
+        fi
+        echo "Downloaded $CONNECT_JAR_NAME"
+        echo ">>> Rebuild the image: ./scripts/createImage.sh"
+        exit 0
+    fi
+
+    echo "Submitting Spark Connect server to Armada (cluster mode, $ALLOCATION_MODE allocation)..."
+
+    # Build spark-submit args (same pattern as submitArmadaSpark.sh)
+    SPARK_SUBMIT_ARGS=(
+        --master $ARMADA_MASTER
+        --deploy-mode cluster
+        --name spark-connect-server
+        --class org.apache.spark.sql.connect.service.SparkConnectServer
+        ${S3_CONF[@]+"${S3_CONF[@]}"}
+        --conf spark.connect.grpc.binding.port=$CONNECT_PORT
+        --conf spark.home=/opt/spark
+        --conf spark.armada.container.image=$IMAGE_NAME
+        --conf spark.armada.queue=$ARMADA_QUEUE
+        --conf spark.armada.lookouturl=${ARMADA_LOOKOUT_URL:-http://localhost:30000}
+        --conf spark.armada.scheduling.namespace=${ARMADA_NAMESPACE:-default}
+        --conf spark.armada.scheduling.nodeUniformity=${ARMADA_NODE_UNIFORMITY_LABEL:-armada-spark}
+        --conf spark.armada.executor.limit.memory=$EXECUTOR_MEMORY_LIMIT
+        --conf spark.armada.executor.request.memory=$EXECUTOR_MEMORY_LIMIT
+        --conf spark.armada.driver.limit.memory=$DRIVER_MEMORY_LIMIT
+        --conf spark.armada.driver.request.memory=$DRIVER_MEMORY_LIMIT
+        --conf spark.kubernetes.executor.disableConfigMap=true
+        --conf spark.local.dir=/tmp
+        --conf spark.jars.ivy=/tmp/.ivy
+    )
+
+    # Allocation mode (-A static|dynamic, same contract as submitArmadaSpark.sh).
+    # Dynamic is the usual choice for a Connect server: it is a long-lived service,
+    # so minExecutors=0 lets it scale to zero while idle and back up on demand.
+    # Static pins a fixed executor count for the server's entire lifetime.
+    if [ "$ALLOCATION_MODE" = "static" ]; then
+        SPARK_SUBMIT_ARGS+=(
+            --conf spark.executor.instances=${EXECUTOR_INSTANCES:-2}
+        )
+    else
+        SPARK_SUBMIT_ARGS+=(
+            --conf spark.dynamicAllocation.enabled=true
+            --conf spark.dynamicAllocation.minExecutors=0
+            --conf spark.dynamicAllocation.maxExecutors=5
+            --conf spark.dynamicAllocation.executorIdleTimeout=60
+            --conf spark.dynamicAllocation.schedulerBacklogTimeout=5
+            --conf spark.dynamicAllocation.initialExecutors=1
+            --conf spark.dynamicAllocation.shuffleTracking.enabled=false
+            --conf spark.decommission.enabled=true
+            --conf spark.storage.decommission.enabled=true
+            --conf spark.storage.decommission.shuffleBlocks.enabled=true
+        )
+    fi
+
+    # Add deploy mode args (internalUrl for cluster mode)
+    SPARK_SUBMIT_ARGS+=(${DEPLOY_MODE_ARGS[@]+"${DEPLOY_MODE_ARGS[@]}"})
+
+    # Add auth args
+    SPARK_SUBMIT_ARGS+=(${ARMADA_AUTH_ARGS[@]+"${ARMADA_AUTH_ARGS[@]}"})
+
+    # Add event log conf
+    SPARK_SUBMIT_ARGS+=(${EVENT_LOG_CONF[@]+"${EVENT_LOG_CONF[@]}"})
+
+    # Add primary resource
+    SPARK_SUBMIT_ARGS+=($CONNECT_JAR_REMOTE)
+
+    # Cluster-mode submit: submits the job and exits (non-zero exit is OK)
+    docker run \
+      --rm --network host \
+      "${DOCKER_ENV_ARGS[@]}" \
+      $IMAGE_NAME \
+      /opt/spark/bin/spark-submit "${SPARK_SUBMIT_ARGS[@]}" || true
+
+    echo ""
+    echo "Spark Connect server submitted."
+    echo ""
+    echo "Port-forward to the driver pod before using Jupyter:"
+    echo "  kubectl port-forward -n ${ARMADA_NAMESPACE:-default} \$(kubectl get pod -n ${ARMADA_NAMESPACE:-default} -l spark-role=driver,spark-app-name=spark-connect-server -o name | head -1) $CONNECT_PORT:$CONNECT_PORT"
+    echo ""
+fi
+
+# ── Start Jupyter container ──
+
 # Remove existing container if it exists
 if docker ps -a --format '{{.Names}}' | grep -q "^armada-jupyter$"; then
     echo "Removing existing armada-jupyter container..."
     docker rm -f armada-jupyter >/dev/null 2>&1 || true
 fi
 
-# Run Jupyter container
-docker run -d \
-  --name armada-jupyter \
-  -p ${JUPYTER_PORT}:8888 \
-  -p ${SPARK_BLOCK_MANAGER_PORT}:${SPARK_BLOCK_MANAGER_PORT} \
-  -p ${SPARK_DRIVER_PORT}:${SPARK_DRIVER_PORT} \
-  -e ARMADA_MASTER=${ARMADA_MASTER} \
-  -e ARMADA_COMMON_CONF="${ARMADA_COMMON_CONF[*]:-}" \
-  -e ARMADA_AUTH_ARGS="${ARMADA_AUTH_ARGS[*]:-}" \
-  -e DEPLOY_MODE_ARGS="${DEPLOY_MODE_ARGS[*]:-}" \
-  -e DYNAMIC_ALLOC_CONF="${DYNAMIC_ALLOC_CONF[*]:-}" \
-  -e STATIC_ALLOC_CONF="${STATIC_ALLOC_CONF[*]:-}" \
-  -e DISTRIBUTED_SHUFFLE_STORAGE_CONF="${DISTRIBUTED_SHUFFLE_STORAGE_CONF[*]:-}" \
-  -e ALLOCATION_MODE=${ALLOCATION_MODE} \
-  -v "$workspace_dir:/home/spark/workspace" \
-  -v "$root/conf:/opt/spark/conf:ro" \
-  --rm \
-  ${IMAGE_NAME} \
-  /opt/spark/bin/jupyter-entrypoint.sh
+if [ "$USE_SPARK_CONNECT" = true ]; then
+    # Spark Connect mode: thin client, no driver ports needed
+    docker run -d \
+      --name armada-jupyter \
+      -p ${JUPYTER_PORT}:8888 \
+      -v "$workspace_dir:/home/spark/workspace" \
+      --rm \
+      ${IMAGE_NAME} \
+      /opt/spark/bin/jupyter-entrypoint.sh
+else
+    # Client mode: driver runs inside, needs ports exposed
+    docker run -d \
+      --name armada-jupyter \
+      -p ${JUPYTER_PORT}:8888 \
+      -p ${SPARK_BLOCK_MANAGER_PORT}:${SPARK_BLOCK_MANAGER_PORT} \
+      -p ${SPARK_DRIVER_PORT}:${SPARK_DRIVER_PORT} \
+      -e ARMADA_MASTER=${ARMADA_MASTER} \
+      -e ARMADA_COMMON_CONF="${ARMADA_COMMON_CONF[*]:-}" \
+      -e ARMADA_AUTH_ARGS="${ARMADA_AUTH_ARGS[*]:-}" \
+      -e DEPLOY_MODE_ARGS="${DEPLOY_MODE_ARGS[*]:-}" \
+      -e DYNAMIC_ALLOC_CONF="${DYNAMIC_ALLOC_CONF[*]:-}" \
+      -e STATIC_ALLOC_CONF="${STATIC_ALLOC_CONF[*]:-}" \
+      -e DISTRIBUTED_SHUFFLE_STORAGE_CONF="${DISTRIBUTED_SHUFFLE_STORAGE_CONF[*]:-}" \
+      -e ALLOCATION_MODE=${ALLOCATION_MODE} \
+      -v "$workspace_dir:/home/spark/workspace" \
+      -v "$root/conf:/opt/spark/conf:ro" \
+      --rm \
+      ${IMAGE_NAME} \
+      /opt/spark/bin/jupyter-entrypoint.sh
+fi
 
 # Wait for Jupyter server to be reachable
 for i in {1..10}; do
@@ -85,6 +223,11 @@ for i in {1..10}; do
         echo "Jupyter notebook is running at http://localhost:${JUPYTER_PORT}"
         echo "Workspace is available in the container at /home/spark/workspace"
         echo "Notebooks are persisted in $workspace_dir"
+        if [ "$USE_SPARK_CONNECT" = true ]; then
+            echo ""
+            echo "Using Spark Connect mode."
+            echo "Connect in notebook with: SparkSession.builder.remote('sc://host.docker.internal:$CONNECT_PORT').getOrCreate()"
+        fi
         exit 0
     fi
     sleep 1

--- a/src/main/scala-spark-3.3/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-3.3/org/apache/spark/deploy/SparkSubmit.scala
@@ -1130,7 +1130,8 @@ private[spark] class SparkSubmit extends Logging {
         throw findCause(t)
     } finally {
       if (
-        args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
+        (args.master.startsWith("k8s") || args.master.startsWith("armada")) &&
+        !isShell(args.primaryResource) &&
         !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass)
       ) {
         try {

--- a/src/main/scala-spark-3.5/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-3.5/org/apache/spark/deploy/SparkSubmit.scala
@@ -317,8 +317,6 @@ private[spark] class SparkSubmit extends Logging {
         error("Cluster deploy mode is not applicable to Spark SQL shell.")
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Thrift server.")
-      case (_, CLUSTER) if isConnectServer(args.mainClass) =>
-        error("Cluster deploy mode is not applicable to Spark Connect server.")
       case _ =>
     }
 
@@ -1183,7 +1181,8 @@ private[spark] class SparkSubmit extends Logging {
         throw findCause(t)
     } finally {
       if (
-        args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
+        (args.master.startsWith("k8s") || args.master.startsWith("armada")) &&
+        !isShell(args.primaryResource) &&
         !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass) &&
         !isConnectServer(args.mainClass)
       ) {

--- a/src/main/scala-spark-4.1/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-4.1/org/apache/spark/deploy/SparkSubmit.scala
@@ -325,8 +325,6 @@ private[spark] class SparkSubmit extends Logging {
         error("Cluster deploy mode is not applicable to Spark SQL shell.")
       case (_, CLUSTER) if isThriftServer(args.mainClass) =>
         error("Cluster deploy mode is not applicable to Spark Thrift server.")
-      case (_, CLUSTER) if isConnectServer(args.mainClass) =>
-        error("Cluster deploy mode is not applicable to Spark Connect server.")
       case _ =>
     }
 
@@ -1170,7 +1168,8 @@ private[spark] class SparkSubmit extends Logging {
         throw findCause(t)
     } finally {
       if (
-        args.master.startsWith("k8s") && !isShell(args.primaryResource) &&
+        (args.master.startsWith("k8s") || args.master.startsWith("armada")) &&
+        !isShell(args.primaryResource) &&
         !isSqlShell(args.mainClass) && !isThriftServer(args.mainClass) &&
         !isConnectServer(args.mainClass)
       ) {


### PR DESCRIPTION
**What:** Add experimental Spark Connect support to `armada-spark` via a `-C` flag on `scripts/runJupyter.sh`.

**Why:** Lets users drive Armada-scheduled Spark from a notebook through Spark Connect, where the driver and Connect server run in the cluster and Jupyter is a thin gRPC client. This avoids running a JVM driver locally and matches how Spark Connect is meant to be used.

**Changes:**
- Add `-C` to `runJupyter.sh`: submits a `SparkConnectServer` in Armada cluster mode, then starts Jupyter as a thin client; without `-C` the existing client-mode behavior is unchanged.
- Honor `-A static|dynamic` for the Connect server (default dynamic, scales to zero when idle); static mode pins executors via `EXECUTOR_INSTANCES`.
- Auto-download the matching `spark-connect` JAR into `extraJars/` and bake it plus Connect Python deps (`pandas`, `pyarrow`, `grpcio`, `grpcio-status`, `protobuf`) into the image.
- Stop the in-cluster `SparkContext` after the app finishes for `armada://` masters (Spark 3.3 / 3.5 / 4.1), mirroring existing `k8s` behavior; remove the cluster-mode Connect-server guard on 3.5 / 4.1.
- Add `example/jupyter/notebooks/spark_connect_demo.ipynb` and a README section documenting the workflow.

**How to verify:**
1. `mvn clean package -DskipTests` then `./scripts/createImage.sh`.
2. `./scripts/runJupyter.sh -C` (first run downloads the JAR and asks for an image rebuild; rerun after).
3. Run the printed `kubectl port-forward` command for connect port `15002`.
4. Open the demo notebook, connect with `SparkSession.builder.remote("sc://host.docker.internal:15002")`, run a query, and confirm executors scale up then back to zero.
5. Repeat with `EXECUTOR_INSTANCES=3 ./scripts/runJupyter.sh -C -A static` and confirm 3 executors stay up.

**Limitation:** Spark Connect server needs to be exposed with port forwarding. No secure way to expose it has been implemented.
