### PR TITLE
Auto download aws jars

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -82,6 +82,7 @@ scripts/armadactl
 *~
 e2e-test.log
 extraJars/*.jar
+benchmark/kubeconfig
 scripts/.tmp/
 
 # Jupyter

--- a/scripts/createDssImage.sh
+++ b/scripts/createDssImage.sh
@@ -34,7 +34,7 @@ cd $repo_dir
 git checkout $branch
 
 export SPARK_HOME=`pwd`
-./build/mvn clean install --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Pscala-2.12
+./build/mvn clean install --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Phadoop-cloud -Pscala-2.12
 ./bin/docker-image-tool.sh -u 185 -t "spark.dss.img"  -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
 cd ..
 

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -48,7 +48,7 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
             # spark-examples jars are not released, so we need to build these from sources
             ./build/mvn --batch-mode clean
             ./build/mvn --batch-mode package -pl examples
-            ./build/mvn --batch-mode package -Pkubernetes -Pscala-$SCALA_BIN_VERSION -pl assembly
+            ./build/mvn --batch-mode package -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION -pl assembly
             ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
             cd ..
         fi


### PR DESCRIPTION
Closes https://github.com/G-Research/gr-oss/issues/1297

According to Enrico's suggestion, I added the -Phadoop-cloud, and it seems to download the expected jars.

Test:
After a new rebuild of the Docker image from scratch:

```bash
ocker run --rm --entrypoint sh spark:armada -c "ls /opt/spark/jars/ | grep -iE 'hadoop-aws|aws-java-sdk-bundle'"
aws-java-sdk-bundle-1.12.262.jar
hadoop-aws-3.3.4.jar
```