### PR TITLE
shade scala-collection-compat

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
                                     <include>com.google.j2objc:j2objc-annotations</include>
                                     <include>com.google.protobuf:protobuf-java</include>
                                     <include>com.thesamet.scalapb:*</include>
+                                    <include>org.scala-lang.modules:scala-collection-compat_${scala.binary.version}</include>
                                     <include>io.grpc:*</include>
                                     <include>io.netty:*</include>
                                     <include>io.perfmark:perfmark-api</include>
@@ -404,6 +405,10 @@
                                 <relocation>
                                     <pattern>scalapb.</pattern>
                                     <shadedPattern>io.armadaproject.shaded.scalapb.</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>scala.collection.compat.</pattern>
+                                    <shadedPattern>io.armadaproject.shaded.scala.collection.compat.</shadedPattern>
                                 </relocation>
                             </relocations>
                             <filters>


### PR DESCRIPTION
Closes https://github.com/G-Research/gr-oss/issues/1339

**Root cause:** Spark 3.3.4 ships with scala-collection-compat version 2.1.1, which does not include the method canBuildFromIterableViewMapLike. This method was first introduced in scala-collection-compat version 2.1.4.

v2.1.1 source (method absent): https://github.com/scala/scala-collection-compat/blob/v2.1.1/compat/src/main/scala-2.12/scala/collection/compat/package.scala

v2.1.4 source (method present): https://github.com/scala/scala-collection-compat/blob/v2.1.4/compat/src/main/scala-2.12/scala/collection/compat/package.scala

**Fix:**
Bundle scala-collection-compat into the fat jar and relocate it under io.armadaproject.shaded.* so shaded scalapb stops resolving against Spark's older runtime copy.