### PR TITLE
Pin shas for github actions

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -17,7 +17,7 @@ runs:
   using: composite
   steps:
   - name: Restore Maven packages cache
-    uses: actions/cache@v4
+    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-build-${{ inputs.spark_version }}-${{ inputs.scala_version }}-${{ hashFiles('pom.xml') }}
@@ -25,7 +25,7 @@ runs:
         ${{ runner.os }}-mvn-build-${{ inputs.spark_version }}-${{ inputs.scala_version }}-${{ hashFiles('pom.xml') }}
         ${{ runner.os }}-mvn-build-${{ inputs.spark_version }}-${{ inputs.scala_version }}-
   - name: Setup JDK
-    uses: actions/setup-java@v4
+    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
     with:
       java-version: ${{ inputs.java_version }}
       distribution: 'zulu'

--- a/.github/actions/e2e/action.yaml
+++ b/.github/actions/e2e/action.yaml
@@ -17,12 +17,12 @@ runs:
   using: composite
   steps:
   - name: Checkout
-    uses: actions/checkout@v4
+    uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
     with:
       path: armada-spark
 
   - name: Restore Maven packages cache
-    uses: actions/cache@v4
+    uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
     with:
       path: ~/.m2/repository
       key: ${{ runner.os }}-mvn-e2e-${{ inputs.spark_version }}-${{ inputs.scala_version }}-${{ hashFiles('armada-spark/pom.xml') }}
@@ -43,13 +43,13 @@ runs:
       echo "::endgroup::"
     shell: bash
   - name: Setup JDK
-    uses: actions/setup-java@v4
+    uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
     with:
       java-version: ${{ inputs.java_version }}
       distribution: 'zulu'
   - name: Setup Go
     id: setup-go
-    uses: armadaproject/armada-operator/.github/actions/setup-go-cache@main
+    uses: armadaproject/armada-operator/.github/actions/setup-go-cache@72ecbbdfddd147af7be300cbea7f0d870004e56c # main
     with:
       cache-prefix: go-e2e
 

--- a/.github/workflows/build-snapshots.yaml
+++ b/.github/workflows/build-snapshots.yaml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         include:
           - scala_version: "2.13.16"
-            spark_version: "4.1.2-SNAPSHOT"
+            spark_version: "4.1.3-SNAPSHOT"
             java_version: "17"
 
     steps:

--- a/.github/workflows/build-snapshots.yaml
+++ b/.github/workflows/build-snapshots.yaml
@@ -19,7 +19,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build
         uses: ./.github/actions/build/
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Build
         uses: ./.github/actions/build/
         with:

--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -29,7 +29,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: E2E
         uses: ./.github/actions/e2e/
         with:

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -11,16 +11,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@c1e323688fd81a25caa38c78aa6df2d33d3e20d9 # v4
         with:
           distribution: zulu
           java-version: '17'
 
       - name: Cache Maven local repository
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-spotless-check-${{ hashFiles('**/pom.xml') }}


### PR DESCRIPTION
Most of these actions are just vanilla github actions and so would probably be safe even without pinning, but I still think there is value in pinning just so we don't have to worry about it.

With these changes, Claude reports we are in good shape:

```
 Here's the scorecard:

  Already secure:
  - Permissions — All 5 workflows set permissions: {} (least privilege). Nothing gets a token it doesn't need.
  - No script injection — No ${{ github.event.* }} interpolated into run: blocks. This is the most common vulnerability in
  GitHub Actions and you don't have it.
  - No secrets — No secrets referenced anywhere, so no leak surface.
  - No pull_request_target — Avoids the classic fork-PR-runs-with-write-access attack.
  - No GITHUB_ENV/GITHUB_PATH — No environment injection vectors.
  - No artifact upload/download — No artifact poisoning surface.
  - SHA pinning — Just completed.

  Nothing actionable remaining. Your CI is simple (lint, build, test), uses no secrets, grants no permissions, and doesn't
  interpolate untrusted input. That's about as locked down as GitHub Actions gets.
```