### PR TITLE
fix(jupyter): make Spark Connect work across Spark versions

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -50,12 +50,9 @@ RUN if [ "$include_python" = "true" ]; then \
             jupyter \
             notebook \
             ipykernel \
-            pyspark==${spark_version} \
             pandas \
-            pyarrow \
-            grpcio \
-            grpcio-status \
-            protobuf && \
+            pyarrow && \
+        pip3 install --no-cache-dir --upgrade "pyspark[connect]==${spark_version}" && \
         apt-get clean && \
         rm -rf /var/lib/apt/lists/*; \
     fi

--- a/scripts/runJupyter.sh
+++ b/scripts/runJupyter.sh
@@ -124,6 +124,7 @@ if [ "$USE_SPARK_CONNECT" = true ]; then
         --conf spark.armada.driver.limit.memory=$DRIVER_MEMORY_LIMIT
         --conf spark.armada.driver.request.memory=$DRIVER_MEMORY_LIMIT
         --conf spark.jars.ivy=/tmp/.ivy
+        --conf spark.armada.driver.watchEnabled=false
     )
 
     # Allocation mode (-A static|dynamic, same contract as submitArmadaSpark.sh).


### PR DESCRIPTION
Base image ships older gRPC/protobuf than Spark Connect needs; pyspark[connect] with --upgrade replaces them with the versions Spark Connect requires. watchEnabled=false stops spark-submit blocking on the long-lived Connect server.