### PR TITLE
Fix script array expansions for compatibility with Bash 3.2

### DIFF
--- a/scripts/submitArmadaSpark.sh
+++ b/scripts/submitArmadaSpark.sh
@@ -40,7 +40,7 @@ fi
 EXTRA_CONF=(
     --conf spark.driver.extraJavaOptions="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
     --conf spark.executor.extraJavaOptions="-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005"
-    "${APP_ID_CONF[@]}"
+    "${APP_ID_CONF[@]-}"
 )
 if [ "$STATIC_MODE" = true ]; then
     echo running static mode
@@ -56,12 +56,12 @@ SPARK_SUBMIT_ARGS=(
     --deploy-mode $DEPLOY_MODE
     --name $NAME
     $CLASS_PROMPT $CLASS_ARG
-    "${S3_CONF[@]}" \
+    "${S3_CONF[@]-}" \
     "${ARMADA_COMMON_CONF[@]}" \
 )
 
 # Add fallback storage / decommission conf if enabled
-SPARK_SUBMIT_ARGS+=("${DISTRIBUTED_SHUFFLE_STORAGE_CONF[@]}")
+SPARK_SUBMIT_ARGS+=("${DISTRIBUTED_SHUFFLE_STORAGE_CONF[@]-}")
 
 # Add deploy mode args
 SPARK_SUBMIT_ARGS+=("${DEPLOY_MODE_ARGS[@]}")
@@ -75,13 +75,23 @@ if [ "${#OAUTH_CONF[@]}" -gt 0 ]; then
 fi
 
 # Add event log conf
-SPARK_SUBMIT_ARGS+=("${EVENT_LOG_CONF[@]}")
+SPARK_SUBMIT_ARGS+=("${EVENT_LOG_CONF[@]-}")
 
 # Add extra conf
 SPARK_SUBMIT_ARGS+=("${EXTRA_CONF[@]}")
 
 # Add application and final args
 SPARK_SUBMIT_ARGS+=($FIRST_ARG "${FINAL_ARGS[@]}")
+
+# On bash 3.2 (macOS), "${empty_arr[@]-}" expands to "" rather than nothing.
+# Filter out any empty strings so spark-submit never receives a bare "" argument
+# (which resolves to the CWD and causes "Is a directory" errors).
+_filtered_args=()
+for _arg in "${SPARK_SUBMIT_ARGS[@]}"; do
+    [ -n "$_arg" ] && _filtered_args+=("$_arg")
+done
+SPARK_SUBMIT_ARGS=("${_filtered_args[@]}")
+unset _filtered_args _arg
 
 # Run spark-submit via docker. In cluster mode, the Scala application watches
 # the driver job internally and exits with the appropriate code.


### PR DESCRIPTION
Due to GPL license changes starting with Bash 4.0, Apple still ships Bash version 3.2 (in `/bin/bash` and `/bin/sh`), which expands shell array parameters differently than more contemporary versions (at least 4.0 or higher) of Bash.

This was causing `submitArmadaSpark.sh` to fail early with several errors like `APP_ID_CONF[@]: unbound variable` on macOS. (It did not manifest on Linux systems, as virtually all of them ship Bash 4.0 or newer, e.g. Ubuntu 22.04 ships Bash 5.2.)

The fix is to specify empty defaults for unset entries, and then to strip out empty string entries in the final result.

For more background information on this, and the various array-expansion incompatibilities between Bash versions (warning: a very messy situation), see https://stackoverflow.com/questions/7577052/unbound-variable-error-in-bash-when-expanding-empty-array

Fixes https://github.com/armadaproject/armada-spark/issues/127