### PR TITLE
Generalize scripts to support dss/benchmarks in Spark 3.3, 3.5, and 4.1

### DIFF
--- a/scripts/createDssImage.sh
+++ b/scripts/createDssImage.sh
@@ -26,7 +26,7 @@ cd $tmp_dir
 
 repo=${ARMADA_DSS_REPO:-https://github.com/G-Research/spark}
 repo_dir=`basename $repo`
-branch=${ARMADA_DSS_BRANCH:-armada/push-task-result-to-driver-bm-v3.5.3}
+branch=${ARMADA_DSS_BRANCH:-armada/push-task-result-to-driver-bm-v${SPARK_VERSION}}
 
 # create the spark image with distributed shuffle storage support
 git clone $repo
@@ -34,8 +34,22 @@ cd $repo_dir
 git checkout $branch
 
 export SPARK_HOME=`pwd`
-./build/mvn clean install --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Phadoop-cloud -Pscala-2.12
-./bin/docker-image-tool.sh -u 185 -t "spark.dss.img"  -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
+DSS_IMAGE_TAG="spark.dss${SPARK_VERSION}.img"
+# eclipse-temurin works with all three versions
+spark_dockerfile="resource-managers/kubernetes/docker/src/main/dockerfiles/spark/Dockerfile"
+if [ -f "$spark_dockerfile" ]; then
+    sed -i -e 's|FROM openjdk:|FROM eclipse-temurin:|g' "$spark_dockerfile"
+    sed -i -e 's|FROM azul/zulu-openjdk:|FROM eclipse-temurin:|g' "$spark_dockerfile"
+    sed -i -e 's|^ARG java_image_name=.*|ARG java_image_name=eclipse-temurin|' "$spark_dockerfile"
+    if [[ "$SPARK_VERSION" == "4."* ]]; then
+        sed -i -E 's/^ARG java_image_tag=.+$/ARG java_image_tag=17-jammy/' "$spark_dockerfile"
+    else
+        sed -i -E 's/^ARG java_image_tag=.+$/ARG java_image_tag=11-jammy/' "$spark_dockerfile"
+    fi
+fi
+./dev/change-scala-version.sh $SCALA_BIN_VERSION
+./build/mvn clean install --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION
+./bin/docker-image-tool.sh -u 185 -t "$DSS_IMAGE_TAG"  -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
 cd ..
 
 # build the benchmarking tools
@@ -50,11 +64,10 @@ popd
 
 # get the benchmark jar files
 mkdir jars
-if [ `basename $ARMADA_BENCHMARK_JAR` == "armada-eks-spark-benchmark-assembly-1.0.jar" ]; then
-    # this was built from https://github.com/GeorgeJahad/eks-spark-benchmark/tree/hashOutput
-    wget --no-check-certificate "https://drive.google.com/uc?export=download&id=1fjGRrLmbLygqdP-ugoTHLUbNMkTTxvcO" \
-         -O  jars/armada-eks-spark-benchmark-assembly-1.0.jar
-fi
+benchmark_jar_basename=$(basename "$ARMADA_BENCHMARK_JAR")
+# built from https://github.com/GeorgeJahad/eks-spark-benchmark/tree/hashOutput
+wget --no-check-certificate "https://drive.google.com/uc?export=download&id=$ARMADA_BENCHMARK_JAR_ID" \
+     -O  "jars/$benchmark_jar_basename"
 
 # Copy the cert file into the docker dir and add docker commands to import it
 # The cert file is need for clusters using TLS with self signed certs
@@ -68,14 +81,14 @@ if [[ $ARMADA_SKIP_CERT != "true" ]]; then
     echo copying $1
     cp $1 ca.crt
     IMPORT_CERT_COMMANDS="COPY ca.crt /tmp/ca.crt
-RUN keytool -importcert -file /tmp/ca.crt -keystore /opt/java/openjdk/lib/security/cacerts -alias mycert -storepass changeit -noprompt"
+RUN keytool -importcert -file /tmp/ca.crt -keystore \$(find / -name cacerts -type f 2>/dev/null | head -1) -alias mycert -storepass changeit -noprompt"
 else
     IMPORT_CERT_COMMANDS=""
 fi
 
 git -C ../$repo_dir rev-parse HEAD > BUILD-COMMIT
 cat <<EOF > Dockerfile
-FROM spark-py:spark.dss.img
+FROM spark-py:$DSS_IMAGE_TAG
 
 # Reset to root to run installation tasks
 USER 0
@@ -87,5 +100,11 @@ COPY BUILD-COMMIT /opt/spark/BUILD-COMMIT
 $IMPORT_CERT_COMMANDS
 EOF
 
-docker build --tag spark-py:spark.dss.img2 .
+docker build --tag spark-py:${DSS_IMAGE_TAG}2 .
+
+echo ""
+echo "DSS image built: spark-py:${DSS_IMAGE_TAG}2"
+echo "To use this image, set in scripts/config.sh:"
+echo "  DSS_PREFIX=spark-py"
+echo "  DSS_TAG=${DSS_IMAGE_TAG}2"
 

--- a/scripts/createDssImage.sh
+++ b/scripts/createDssImage.sh
@@ -8,6 +8,7 @@ set -e
 
 
 scripts="$(cd "$(dirname "$0")"; pwd)"
+USE_DISTRIBUTED_SHUFFLE_STORAGE=true
 source "$scripts/init.sh"
 
 # these utilities are needed to build benchmarking tools
@@ -84,7 +85,7 @@ if [[ $ARMADA_SKIP_CERT != "true" ]]; then
     echo copying $1
     cp $1 ca.crt
     IMPORT_CERT_COMMANDS="COPY ca.crt /tmp/ca.crt
-RUN keytool -importcert -file /tmp/ca.crt -keystore \$(find / -name cacerts -type f 2>/dev/null | head -1) -alias mycert -storepass changeit -noprompt"
+RUN keytool -importcert -file /tmp/ca.crt -keystore \$(find /usr /opt -name cacerts -type f 2>/dev/null | head -1) -alias mycert -storepass changeit -noprompt"
 else
     IMPORT_CERT_COMMANDS=""
 fi

--- a/scripts/createDssImage.sh
+++ b/scripts/createDssImage.sh
@@ -26,12 +26,15 @@ cd $tmp_dir
 
 repo=${ARMADA_DSS_REPO:-https://github.com/G-Research/spark}
 repo_dir=`basename $repo`
-branch=${ARMADA_DSS_BRANCH:-armada/push-task-result-to-driver-bm-v${SPARK_VERSION}}
+branch=${DSS_BRANCH}
 
 # create the spark image with distributed shuffle storage support
 git clone $repo
 cd $repo_dir
 git checkout $branch
+
+# Suppress unused-imports warning
+sed -i 's|<arg>-Ywarn-unused:imports</arg>|<!-- <arg>-Ywarn-unused:imports</arg> -->|' pom.xml
 
 export SPARK_HOME=`pwd`
 DSS_IMAGE_TAG="spark.dss${SPARK_VERSION}.img"

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -304,6 +304,7 @@ if [[ "$SPARK_VERSION" == "4."* ]]; then
     ARMADA_BENCHMARK_JAR=${ARMADA_BENCHMARK_JAR:-local:///opt/spark/jars/armada-eks-spark-benchmark-assembly-411-1.0.jar}
     ARMADA_BENCHMARK_JAR_ID=${ARMADA_BENCHMARK_JAR_ID:-1fxbOFli52VQQyK2IX2WxEW1XAjWRU4XX}
 else
+    # The 353 benchmark jar works for 334 as well
     ARMADA_BENCHMARK_JAR=${ARMADA_BENCHMARK_JAR:-local:///opt/spark/jars/armada-eks-spark-benchmark-assembly-353-1.0.jar}
     ARMADA_BENCHMARK_JAR_ID=${ARMADA_BENCHMARK_JAR_ID:-1fjGRrLmbLygqdP-ugoTHLUbNMkTTxvcO}
 fi

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -284,7 +284,7 @@ if [ "$USE_DISTRIBUTED_SHUFFLE_STORAGE" = "true" ]; then
             ;;
         3.5.3:2.12)
             DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-353-1}
-            DSS_BRANCH=${DSS_BRANCH:-fallback-storage-retry-from-fallback-v3.5.3}
+            DSS_BRANCH=${DSS_BRANCH:-armada/push-task-result-to-driver-bm-v3.5.3}
             ;;
         4.1.1:2.13)
             DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-411-1}

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -19,7 +19,6 @@ ARMADA_S3_BUCKET_ENDPOINT=${ARMADA_S3_BUCKET_ENDPOINT:-http://192.168.59.6}
 ARMADA_S3_USER_DIR=${ARMADA_USER_DIR:-s3a://$ARMADA_S3_BUCKET_NAME/$USER}
 
 # benchmark
-ARMADA_BENCHMARK_JAR=${ARMADA_BENCHMARK_JAR:-local:///opt/spark/jars/armada-eks-spark-benchmark-assembly-1.0.jar}
 ARMADA_BENCHMARK_DATA=${ARMADA_BENCHMARK_DATA:-s3a://kafka-s3/data/benchmark/data/10t}
 ARMADA_BENCHMARK_CLASS=${ARMADA_BENCHMARK_CLASS:-com.amazonaws.eks.tpcds.BenchmarkSQL}
 ARMADA_BENCHMARK_TOOLS=${ARMADA_BENCHMARK_TOOLS:-/opt/tools/tpcds-kit/tools}
@@ -275,6 +274,37 @@ if [[ -z "${SPARK_VERSION:-}" ]]; then
   export SPARK_BIN_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=spark.binary.version -q -DforceStdout)
 fi
 
+# When using DSS, validate Spark version + Scala version against known DSS base
+# images and set DSS_PREFIX/DSS_TAG defaults
+if [ "$USE_DISTRIBUTED_SHUFFLE_STORAGE" = "true" ]; then
+    case "${SPARK_VERSION}:${SCALA_BIN_VERSION}" in
+        3.3.4:2.12)
+            DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-334-1}
+            ;;
+        3.5.3:2.12)
+            DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-353-1}
+            ;;
+        4.1.1:2.13)
+            DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-411-1}
+            ;;
+        *)
+            echo "Error: unsupported Spark/Scala combination for DSS: ${SPARK_VERSION} / ${SCALA_BIN_VERSION}"
+            exit 1
+            ;;
+    esac
+    DSS_TAG=${DSS_TAG:-latest}
+    export DSS_PREFIX DSS_TAG
+fi
+
+# Benchmark jar and download ID, keyed by Spark major version
+if [[ "$SPARK_VERSION" == "4."* ]]; then
+    ARMADA_BENCHMARK_JAR=${ARMADA_BENCHMARK_JAR:-local:///opt/spark/jars/armada-eks-spark-benchmark-assembly-411-1.0.jar}
+    ARMADA_BENCHMARK_JAR_ID=${ARMADA_BENCHMARK_JAR_ID:-1fxbOFli52VQQyK2IX2WxEW1XAjWRU4XX}
+else
+    ARMADA_BENCHMARK_JAR=${ARMADA_BENCHMARK_JAR:-local:///opt/spark/jars/armada-eks-spark-benchmark-assembly-353-1.0.jar}
+    ARMADA_BENCHMARK_JAR_ID=${ARMADA_BENCHMARK_JAR_ID:-1fjGRrLmbLygqdP-ugoTHLUbNMkTTxvcO}
+fi
+export ARMADA_BENCHMARK_JAR ARMADA_BENCHMARK_JAR_ID
 export CLASS_PATH="${CLASS_PATH:-local:///opt/spark/examples/jars/spark-examples.jar}"
 
 # check the Spark version is supported
@@ -284,11 +314,12 @@ if ! [ -e "$root/src/main/scala-spark-$SPARK_BIN_VERSION" ]; then
 fi
 
 # Distributed shuffle storage / fallback storage conf args
+ARMADA_DSS_PATH="${ARMADA_DSS_PATH:-${ARMADA_S3_USER_DIR}/shuffle/}"
 DISTRIBUTED_SHUFFLE_STORAGE_CONF=()
 if [ "$USE_DISTRIBUTED_SHUFFLE_STORAGE" = "true" ]; then
     DISTRIBUTED_SHUFFLE_STORAGE_CONF=(
         --conf spark.storage.decommission.shuffleBlocks.maxDiskSize=0
-        --conf spark.storage.decommission.fallbackStorage.path=$ARMADA_S3_USER_DIR/shuffle/
+        --conf spark.storage.decommission.fallbackStorage.path=$ARMADA_DSS_PATH
         --conf spark.storage.decommission.fallbackStorage.cleanUp=true
         --conf spark.storage.decommission.fallbackStorage.proactive.enabled=true
         --conf spark.storage.decommission.fallbackStorage.proactive.reliable=true

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -280,12 +280,15 @@ if [ "$USE_DISTRIBUTED_SHUFFLE_STORAGE" = "true" ]; then
     case "${SPARK_VERSION}:${SCALA_BIN_VERSION}" in
         3.3.4:2.12)
             DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-334-1}
+            DSS_BRANCH=${DSS_BRANCH:-fallback-storage-multithread-read-v3.3.4}
             ;;
         3.5.3:2.12)
             DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-353-1}
+            DSS_BRANCH=${DSS_BRANCH:-fallback-storage-retry-from-fallback-v3.5.3}
             ;;
         4.1.1:2.13)
             DSS_PREFIX=${DSS_PREFIX:-gbj262/dss-411-1}
+            DSS_BRANCH=${DSS_BRANCH:-fallback-storage-proactive}
             ;;
         *)
             echo "Error: unsupported Spark/Scala combination for DSS: ${SPARK_VERSION} / ${SCALA_BIN_VERSION}"


### PR DESCRIPTION
**Why:** The DSS image build (`createDssImage.sh`) was hardcoded to Spark 3.5 with Scala 2.12 and a single benchmark jar. Benchmark and DSS configuration in `init.sh` also assumed a single Spark version. These changes make both scripts version-aware so the same workflow supports all three target Spark versions.

**Changes:**
- Parameterize DSS repo branch, image tag, Scala version, and Maven profile by `$SPARK_VERSION` and `$SCALA_BIN_VERSION` in `createDssImage.sh`
- Normalize base Docker image to `eclipse-temurin` across all Spark versions, with Java 17 for Spark 4.x and Java 11 otherwise
- Use dynamic `find` to locate the `cacerts` keystore path instead of hardcoding the OpenJDK path
- Replace conditional benchmark jar download with version-keyed Google Drive IDs (`$ARMADA_BENCHMARK_JAR_ID`)
- Add `case` block in `init.sh` mapping Spark/Scala version pairs to pre-built DSS image prefixes, with `exit 1` for unsupported combinations
- Set `ARMADA_BENCHMARK_JAR` and `ARMADA_BENCHMARK_JAR_ID` defaults based on Spark major version (4.x vs 3.x)
- Add configurable `ARMADA_DSS_PATH` for the shuffle fallback storage path
