### PR TITLE
Feature/multi arch image

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,18 @@ mvn clean package
 | `-p` | Include Python     |                            |
 | `-h` | Display help       |                            |
 
+By default the image is built for the host architecture only and loaded into
+the local docker daemon. Set `PUSH=true` to build a multi-arch image
+(`linux/amd64` + `linux/arm64`) and push it as a manifest list to the registry
+named by `IMAGE_NAME`:
+
+```bash
+PUSH=true ./scripts/createImage.sh
+```
+
+This lets a single image name serve mixed environments, for example building
+on an Apple Silicon Mac (native arm64, no emulation) while amd64 cluster nodes
+pull the amd64 variant of the same tag.
 
 You can store defaults in `scripts/config.sh`:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,12 +16,8 @@
 #
 ARG spark_base_image_prefix=apache/spark
 ARG spark_base_image_tag=3.3.3-scala2.12-java11-ubuntu
-# TARGETARCH is auto-populated by BuildKit (amd64 or arm64) to match the
-# build platform; scripts/createImage.sh tags the per-platform base as
-# `<prefix>:<tag>-<arch>`. Deliberately declared WITHOUT a default: a declared
-# default would override BuildKit's auto-injected value and pin every build to
-# one arch. Legacy-builder invocations outside createImage.sh must pass
-# --build-arg TARGETARCH=<amd64|arm64> explicitly.
+
+# TARGETARCH is auto-populated by BuildKit (amd64 or arm64) to match the build platform.
 ARG TARGETARCH
 
 FROM ${spark_base_image_prefix}:${spark_base_image_tag}-${TARGETARCH}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,12 @@
 #
 ARG spark_base_image_prefix=apache/spark
 ARG spark_base_image_tag=3.3.3-scala2.12-java11-ubuntu
-# TARGETARCH is auto-populated by buildx (amd64 or arm64). scripts/createImage.sh
-# tags the locally-built base as `<prefix>:<tag>-<arch>` per platform.
+# TARGETARCH is auto-populated by BuildKit (amd64 or arm64) to match the
+# build platform; scripts/createImage.sh tags the per-platform base as
+# `<prefix>:<tag>-<arch>`. Deliberately declared WITHOUT a default: a declared
+# default would override BuildKit's auto-injected value and pin every build to
+# one arch. Legacy-builder invocations outside createImage.sh must pass
+# --build-arg TARGETARCH=<amd64|arm64> explicitly.
 ARG TARGETARCH
 
 FROM ${spark_base_image_prefix}:${spark_base_image_tag}-${TARGETARCH}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -17,7 +17,10 @@
 ARG spark_base_image_prefix=apache/spark
 ARG spark_base_image_tag=3.3.3-scala2.12-java11-ubuntu
 
-# TARGETARCH is auto-populated by BuildKit (amd64 or arm64) to match the build platform.
+# TARGETARCH is auto-populated by BuildKit (amd64 or arm64) to match the
+# target platform; plain `docker build` uses BuildKit on all recent Docker
+# versions (default since 20.10).
+# On the legacy, non-BuildKit builder, pass --build-arg TARGETARCH=<amd64|arm64> explicitly.
 ARG TARGETARCH
 
 FROM ${spark_base_image_prefix}:${spark_base_image_tag}-${TARGETARCH}

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -16,8 +16,11 @@
 #
 ARG spark_base_image_prefix=apache/spark
 ARG spark_base_image_tag=3.3.3-scala2.12-java11-ubuntu
+# TARGETARCH is auto-populated by buildx (amd64 or arm64). scripts/createImage.sh
+# tags the locally-built base as `<prefix>:<tag>-<arch>` per platform.
+ARG TARGETARCH
 
-FROM ${spark_base_image_prefix}:${spark_base_image_tag}
+FROM ${spark_base_image_prefix}:${spark_base_image_tag}-${TARGETARCH}
 
 ARG scala_binary_version=2.13
 ARG spark_version=3.3.3

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -92,15 +92,41 @@ done
 
 source "$scripts/prepExtraFiles.sh"
 
-echo "using spark image: $image_prefix:$image_tag-<arch> for ${TARGET_PLATFORMS[*]}"
-docker buildx build \
-  --platform "$(IFS=,; echo "${TARGET_PLATFORMS[*]}")" \
-  --tag $IMAGE_NAME \
-  --build-arg spark_base_image_prefix=$image_prefix \
-  --build-arg spark_base_image_tag=$image_tag \
-  --build-arg scala_binary_version=$SCALA_BIN_VERSION \
-  --build-arg spark_version=$SPARK_VERSION \
-  --build-arg include_python=$INCLUDE_PYTHON \
-  -f "$root/docker/Dockerfile" \
-  $([ "${PUSH:-false}" = "true" ] && echo "--push" || echo "--load") \
-  "$root"
+build_args=(
+  --build-arg spark_base_image_prefix=$image_prefix
+  --build-arg spark_base_image_tag=$image_tag
+  --build-arg scala_binary_version=$SCALA_BIN_VERSION
+  --build-arg spark_version=$SPARK_VERSION
+  --build-arg include_python=$INCLUDE_PYTHON
+  -f "$root/docker/Dockerfile"
+)
+
+# Each platform is built separately with plain `docker build`, which always
+# resolves FROM against the daemon's local image store. This keeps the
+# locally-tagged base images visible regardless of buildx builder type or
+# image store (classic or containerd); a single multi-platform buildx build
+# would require a builder that cannot see local images. 
+# BuildKit is needed for TARGETARCH and --platform.
+export DOCKER_BUILDKIT=1
+
+if [ "${PUSH:-false}" = "true" ]; then
+    # Build and push one image per arch, then assemble them into a multi-arch
+    # manifest list under the bare $IMAGE_NAME. imagetools talks to the
+    # registry directly, so this works with any builder configuration.
+    ARCH_TAGS=()
+    for plat in "${TARGET_PLATFORMS[@]}"; do
+        arch="${plat##*/}"
+        case "$IMAGE_NAME" in
+            *:*) arch_tag="$IMAGE_NAME-$arch" ;;
+            *)   arch_tag="$IMAGE_NAME:$arch" ;;
+        esac
+        echo "Building $arch_tag from base $image_prefix:$image_tag-$arch..."
+        docker build --platform "$plat" --tag "$arch_tag" "${build_args[@]}" "$root"
+        docker push "$arch_tag"
+        ARCH_TAGS+=("$arch_tag")
+    done
+    docker buildx imagetools create --tag "$IMAGE_NAME" "${ARCH_TAGS[@]}"
+else
+    echo "using spark image: $image_prefix:$image_tag-$HOST_ARCH"
+    docker build --platform "linux/$HOST_ARCH" --tag "$IMAGE_NAME" "${build_args[@]}" "$root"
+fi

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -37,13 +37,15 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
         fi
         # Build base image per target platform, tagging with -$arch suffix.
         # The app Dockerfile picks the right one via $TARGETARCH in FROM.
+        missing_platforms=()
         for plat in "${TARGET_PLATFORMS[@]}"; do
             arch="${plat##*/}"
-            if docker image inspect "$image_prefix:$image_tag-$arch" >/dev/null 2>/dev/null; then
-                continue
+            if ! docker image inspect "$image_prefix:$image_tag-$arch" >/dev/null 2>&1; then
+                missing_platforms+=("$plat")
             fi
+        done
+        if [ "${#missing_platforms[@]}" -gt 0 ]; then
             echo "There are no Docker images released for Spark $SPARK_VERSION and Scala $SCALA_BIN_VERSION."
-            echo "Building Spark Docker image $image_prefix:$image_tag-$arch for $plat from source."
             if [[ ! -d ".spark-$SPARK_VERSION" ]]; then
                 echo "Checking out Spark sources for tag v$SPARK_VERSION."
                 git clone https://github.com/apache/spark --branch v$SPARK_VERSION --depth 1 --no-tags ".spark-$SPARK_VERSION"
@@ -61,18 +63,23 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
             fi
             ./dev/change-scala-version.sh $SCALA_BIN_VERSION
             # by packaging the assembly project specifically, jars of all depending Spark projects are fetch from Maven
-            # spark-examples jars are not released, so we need to build these from sources
+            # spark-examples jars are not released, so we need to build these from sources.
+            # The jars are platform agnostic, so a single Maven build serves every
+            # target platform; only the docker image build below runs per arch.
             ./build/mvn --batch-mode clean
             ./build/mvn --batch-mode package -pl examples
             ./build/mvn --batch-mode package -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION -pl assembly
-            DOCKER_DEFAULT_PLATFORM="$plat" ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
+            for plat in "${missing_platforms[@]}"; do
+                arch="${plat##*/}"
+                echo "Building Spark Docker image $image_prefix:$image_tag-$arch for $plat from source."
+                DOCKER_DEFAULT_PLATFORM="$plat" ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
+                # docker-image-tool.sh tags as `$image_prefix:$image_tag`; rename to the
+                # arch-suffixed tag so each platform keeps a distinct base image.
+                docker tag "$image_prefix:$image_tag" "$image_prefix:$image_tag-$arch"
+                docker rmi "$image_prefix:$image_tag" 2>/dev/null || true
+            done
             cd ..
-            # docker-image-tool.sh tags as `$image_prefix:$image_tag`; rename to
-            # the arch-suffixed tag so the next iteration's bare-tag inspect
-            # doesn't match the wrong arch.
-            docker tag "$image_prefix:$image_tag" "$image_prefix:$image_tag-$arch"
-            docker rmi "$image_prefix:$image_tag" 2>/dev/null || true
-        done
+        fi
 fi
 
 

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -7,6 +7,17 @@ root="$(cd "$(dirname "$0")/.."; pwd)"
 scripts="$(cd "$(dirname "$0")"; pwd)"
 source "$scripts/init.sh"
 
+# Default builds for host arch only (fast, native). PUSH=true builds both
+# linux/amd64 and linux/arm64 and pushes a multi-arch manifest list to Docker
+# Hub under $IMAGE_NAME. Cross-arch base build runs under QEMU emulation and
+# is slow the first time, but per-arch base images are cached afterward.
+HOST_ARCH=$(uname -m | sed 's|x86_64|amd64|;s|aarch64|arm64|')
+if [ "${PUSH:-false}" = "true" ]; then
+    TARGET_PLATFORMS=(linux/amd64 linux/arm64)
+else
+    TARGET_PLATFORMS=("linux/$HOST_ARCH")
+fi
+
 image_prefix=apache/spark
 
 if [ "$USE_DISTRIBUTED_SHUFFLE_STORAGE" == "true" ]; then
@@ -24,14 +35,19 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
             image_prefix=spark-py
             extra_build_params=" -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile "
         fi
-        if ! docker image inspect "$image_prefix:$image_tag" >/dev/null 2>/dev/null; then
+        # Build base image per target platform, tagging with -$arch suffix.
+        # The app Dockerfile picks the right one via $TARGETARCH in FROM.
+        for plat in "${TARGET_PLATFORMS[@]}"; do
+            arch="${plat##*/}"
+            if docker image inspect "$image_prefix:$image_tag-$arch" >/dev/null 2>/dev/null; then
+                continue
+            fi
             echo "There are no Docker images released for Spark $SPARK_VERSION and Scala $SCALA_BIN_VERSION."
-            echo "A Docker image has to be built from Spark sources locally."
+            echo "Building Spark Docker image $image_prefix:$image_tag-$arch for $plat from source."
             if [[ ! -d ".spark-$SPARK_VERSION" ]]; then
                 echo "Checking out Spark sources for tag v$SPARK_VERSION."
                 git clone https://github.com/apache/spark --branch v$SPARK_VERSION --depth 1 --no-tags ".spark-$SPARK_VERSION"
             fi
-            echo "Building Spark Docker image $image_prefix:$image_tag."
             cd ".spark-$SPARK_VERSION"
             # Spark 3.3.4 does not compile without this fix
             if [[ "$SPARK_VERSION" == "3.3.4" ]]; then
@@ -49,16 +65,36 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
             ./build/mvn --batch-mode clean
             ./build/mvn --batch-mode package -pl examples
             ./build/mvn --batch-mode package -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION -pl assembly
-            ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
+            DOCKER_DEFAULT_PLATFORM="$plat" ./bin/docker-image-tool.sh -t "$image_tag" $extra_build_params build
             cd ..
-        fi
+            # docker-image-tool.sh tags as `$image_prefix:$image_tag`; rename to
+            # the arch-suffixed tag so the next iteration's bare-tag inspect
+            # doesn't match the wrong arch.
+            docker tag "$image_prefix:$image_tag" "$image_prefix:$image_tag-$arch"
+            docker rmi "$image_prefix:$image_tag" 2>/dev/null || true
+        done
 fi
 
 
+# The app Dockerfile pins its base as `<prefix>:<tag>-<arch>`. Bases built
+# from source above are tagged that way already; registry bases (official
+# apache/spark or DSS images) publish multi-arch manifests under the bare
+# tag, so pull each platform and retag it with the arch suffix.
+for plat in "${TARGET_PLATFORMS[@]}"; do
+    arch="${plat##*/}"
+    if ! docker image inspect "$image_prefix:$image_tag-$arch" >/dev/null 2>&1; then
+        echo "Pulling base $image_prefix:$image_tag for $plat..."
+        docker pull --platform "$plat" "$image_prefix:$image_tag"
+        docker tag "$image_prefix:$image_tag" "$image_prefix:$image_tag-$arch"
+        docker rmi "$image_prefix:$image_tag" >/dev/null 2>&1 || true
+    fi
+done
+
 source "$scripts/prepExtraFiles.sh"
 
-echo using spark image: $image_prefix:$image_tag
-docker build \
+echo "using spark image: $image_prefix:$image_tag-<arch> for ${TARGET_PLATFORMS[*]}"
+docker buildx build \
+  --platform "$(IFS=,; echo "${TARGET_PLATFORMS[*]}")" \
   --tag $IMAGE_NAME \
   --build-arg spark_base_image_prefix=$image_prefix \
   --build-arg spark_base_image_tag=$image_tag \
@@ -66,4 +102,5 @@ docker build \
   --build-arg spark_version=$SPARK_VERSION \
   --build-arg include_python=$INCLUDE_PYTHON \
   -f "$root/docker/Dockerfile" \
+  $([ "${PUSH:-false}" = "true" ] && echo "--push" || echo "--load") \
   "$root"

--- a/scripts/prepExtraFiles.sh
+++ b/scripts/prepExtraFiles.sh
@@ -3,8 +3,12 @@
 if [ "${RUNNING_E2E_TESTS}" == "true" ]; then
     #Generate e2e data for extraFiles directory
     rm -rf $scripts/../extraFiles/*
-    echo Copying extrafiles from $image_prefix:$image_tag
-    id=$(docker create $image_prefix:$image_tag)
+    # Base images are tagged per arch as `<prefix>:<tag>-<arch>` by
+    # createImage.sh; the extracted example jars are platform agnostic, so the
+    # host-arch copy serves.
+    base_image="$image_prefix:$image_tag-$HOST_ARCH"
+    echo Copying extrafiles from $base_image
+    id=$(docker create $base_image)
     docker cp $id:/opt/spark/examples/jars  $scripts/../extraFiles
     docker cp $id:/opt/spark/examples/src  $scripts/../extraFiles
     docker rm -v $id


### PR DESCRIPTION
Related to https://github.com/armadaproject/armada-spark/issues/129

**What:** Build the armada-spark docker image as a multi-arch (`linux/amd64` + `linux/arm64`) manifest list, with native per-architecture base images.

**Why:** A common dev loop is building on macOS (Apple Silicon, arm64) and submitting jobs to a Linux amd64 cluster. With a single-arch image that means either QEMU emulation on the Mac (slow spark-submit and Jupyter containers) or maintaining two image tags. With a multi-arch manifest, one `IMAGE_NAME` serves both: the Mac's docker pulls native arm64, cluster nodes pull amd64. 

**Changes:**

- `scripts/createImage.sh` builds for the host architecture only by default (fast, `--load`); `PUSH=true` builds both platforms via buildx and pushes a manifest list to the registry named by `IMAGE_NAME`
- Spark base images built from source (versions with no published image, e.g. Spark 3.x + Scala 2.13) are built once per platform and tagged `<prefix>:<tag>-<arch>`
- Registry bases (official `apache/spark`, DSS) are pulled per platform and retagged with the same arch suffix, so every base source satisfies one contract
- `docker/Dockerfile` takes buildx's `TARGETARCH` and pins `FROM <prefix>:<tag>-<arch>`, so each platform build uses the matching base
- README documents the `PUSH=true` mode
