### PR TITLE
add JWT auth interceptor for spark connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -250,15 +250,19 @@ Conf reference:
 | Conf | Required | Default | Purpose |
 | --- | --- | --- | --- |
 | `spark.armada.connect.owner` | yes | none | The `sub` value the bearer token must carry to be accepted. Driver fails to start if unset. |
-| `spark.armada.connect.oidc.issuerUrl` | yes | none | OIDC issuer used for `iss` validation and JWKS discovery at `<issuer>/.well-known/openid-configuration`. |
+| `spark.armada.connect.oidc.issuerUrl` | yes | none | OIDC issuer used for `iss` validation and JWKS discovery at `<issuer>/.well-known/openid-configuration`. Must be `https`. |
 | `spark.armada.connect.oidc.audience` | no | none | If set, the `aud` claim is enforced. |
-| `spark.armada.connect.oidc.jwksUrl` | no | discovered | Skip OIDC discovery and use this JWKS URL directly. |
+| `spark.armada.connect.oidc.jwksUrl` | no | discovered | Skip OIDC discovery and use this JWKS URL directly. Must be `https`. |
 
 At runtime the interceptor:
 
 - requires a bearer JWT on every gRPC call,
-- validates signature (RS256 against the IdP's JWKS), issuer, expiry, and (when set) audience,
+- validates signature, issuer, expiry, and (when set) audience,
 - compares the token's `sub` claim against `spark.armada.connect.owner`, rejecting non-matches with `PERMISSION_DENIED`.
+
+Only RS256-signed tokens are supported; tokens signed with other algorithms (e.g. ES256) are
+rejected. A token must carry an `exp` claim: one without an expiry is rejected rather than treated
+as non-expiring.
 
 Obtain a JWT from your OIDC provider and pass it from the client:
 

--- a/README.md
+++ b/README.md
@@ -251,7 +251,7 @@ Conf reference:
 | --- | --- | --- | --- |
 | `spark.armada.connect.owner` | yes | none | The `sub` value the bearer token must carry to be accepted. Driver fails to start if unset. |
 | `spark.armada.connect.oidc.issuerUrl` | yes | none | OIDC issuer used for `iss` validation and JWKS discovery at `<issuer>/.well-known/openid-configuration`. Must be `https`. |
-| `spark.armada.connect.oidc.audience` | no | none | If set, the `aud` claim is enforced. |
+| `spark.armada.connect.oidc.audience` | no | none | If set, the `aud` claim is enforced. If unset, `aud` is not validated and any token the issuer minted (for any audience) is accepted when its `sub` matches the owner; the driver logs a warning at startup. |
 | `spark.armada.connect.oidc.jwksUrl` | no | discovered | Skip OIDC discovery and use this JWKS URL directly. Must be `https`. |
 
 At runtime the interceptor:

--- a/README.md
+++ b/README.md
@@ -228,6 +228,47 @@ Use `kubectl port-forward` command for the connect port (`15002`). Allocation fo
 
 See [`spark_connect_demo.ipynb`](example/jupyter/notebooks/spark_connect_demo.ipynb).
 
+##### Securing Spark Connect with JWT
+
+The Spark Connect server can be locked down so only the user who submitted it can issue gRPC calls. The interceptor (`io.armadaproject.spark.connect.auth.JwtAuthInterceptor`) ships in a separate `connect-auth` JAR (`armada-cluster-manager_*-connect-auth.jar`) that relocates `io.grpc` to Spark Connect's `org.sparkproject.connect.grpc` namespace, so the interceptor implements the gRPC type the Connect runtime expects. The JAR is baked into the image.
+
+Enable it by registering the interceptor and providing its configuration as Spark confs on the Connect server (cluster-mode submit):
+
+```bash
+--conf spark.connect.grpc.interceptor.classes=io.armadaproject.spark.connect.auth.JwtAuthInterceptor
+--conf spark.armada.connect.owner=<token-sub-value>
+--conf spark.armada.connect.oidc.issuerUrl=https://idp.example/
+--conf spark.armada.connect.oidc.audience=spark-connect           # optional, aud not enforced if unset
+--conf spark.armada.connect.oidc.jwksUrl=https://idp.example/jwks  # optional, default is OIDC discovery
+```
+
+The caller's identity is always the token's `sub` claim (IdP-assigned and immutable,
+so it cannot be self-asserted). Set `owner` to that `sub` value.
+
+Conf reference:
+
+| Conf | Required | Default | Purpose |
+| --- | --- | --- | --- |
+| `spark.armada.connect.owner` | yes | none | The `sub` value the bearer token must carry to be accepted. Driver fails to start if unset. |
+| `spark.armada.connect.oidc.issuerUrl` | yes | none | OIDC issuer used for `iss` validation and JWKS discovery at `<issuer>/.well-known/openid-configuration`. |
+| `spark.armada.connect.oidc.audience` | no | none | If set, the `aud` claim is enforced. |
+| `spark.armada.connect.oidc.jwksUrl` | no | discovered | Skip OIDC discovery and use this JWKS URL directly. |
+
+At runtime the interceptor:
+
+- requires a bearer JWT on every gRPC call,
+- validates signature (RS256 against the IdP's JWKS), issuer, expiry, and (when set) audience,
+- compares the token's `sub` claim against `spark.armada.connect.owner`, rejecting non-matches with `PERMISSION_DENIED`.
+
+Obtain a JWT from your OIDC provider and pass it from the client:
+
+```python
+from pyspark.sql import SparkSession
+token = "<jwt>"
+spark = SparkSession.builder.remote(f"sc://spark-connect.example.com:443/;use_ssl=true;token={token}").getOrCreate()
+spark.range(10).count()
+```
+
 ### Spark History Server
 
 View event logs from completed jobs:

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,6 +30,7 @@ ARG spark_version=3.3.3
 ARG include_python=false
 
 COPY target/armada-cluster-manager_${scala_binary_version}-*-all.jar /opt/spark/jars/
+COPY target/armada-cluster-manager_${scala_binary_version}-*-connect-auth.jar /opt/spark/jars/
 COPY extraFiles /opt/spark/extraFiles
 COPY extraJars/* /opt/spark/jars
 COPY docker/jupyter-entrypoint.sh /opt/spark/bin/jupyter-entrypoint.sh

--- a/pom.xml
+++ b/pom.xml
@@ -167,13 +167,10 @@
             <artifactId>jwks-rsa</artifactId>
             <version>0.22.1</version>
         </dependency>
-        <!-- gRPC SPI the interceptor implements; pinned to armada-scala-client's
-             gRPC version so the main shaded JAR is unaffected. -->
-        <dependency>
-            <groupId>io.grpc</groupId>
-            <artifactId>grpc-api</artifactId>
-            <version>1.67.1</version>
-        </dependency>
+        <!-- The interceptor implements the gRPC SPI (io.grpc.ServerInterceptor). grpc-api is not
+             declared explicitly: it comes transitively from armada-scala-client, so the version
+             always matches the client's and cannot drift. -->
+
 
         <!-- Test dependencies -->
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -439,6 +439,17 @@
                                     </excludes>
                                 </filter>
                                 <filter>
+                                    <!-- The Spark Connect auth interceptor lives ONLY in the
+                                         connect-auth jar, where gRPC is relocated to Spark Connect's
+                                         namespace. Exclude it here so this jar's copy (with the main
+                                         io.armadaproject.shaded relocation) can't shadow it on the
+                                         classpath and break the interceptor-registry cast. -->
+                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
+                                    <excludes>
+                                        <exclude>io/armadaproject/spark/connect/auth/**</exclude>
+                                    </excludes>
+                                </filter>
+                                <filter>
                                     <artifact>*:*</artifact>
                                     <excludes>
                                         <exclude>META-INF/io.netty.versions.properties</exclude>

--- a/pom.xml
+++ b/pom.xml
@@ -156,6 +156,25 @@
           <version>0.3.0</version>
         </dependency>
 
+        <!-- JWT verification for the Spark Connect auth interceptor -->
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>java-jwt</artifactId>
+            <version>4.4.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.auth0</groupId>
+            <artifactId>jwks-rsa</artifactId>
+            <version>0.22.1</version>
+        </dependency>
+        <!-- gRPC SPI the interceptor implements; pinned to armada-scala-client's
+             gRPC version so the main shaded JAR is unaffected. -->
+        <dependency>
+            <groupId>io.grpc</groupId>
+            <artifactId>grpc-api</artifactId>
+            <version>1.67.1</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
           <groupId>org.scalatest</groupId>
@@ -429,6 +448,59 @@
                             </filters>
                             <shadedArtifactAttached>true</shadedArtifactAttached>
                             <shadedClassifierName>all</shadedClassifierName>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>connect-auth-jar</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <!-- Separate "connect-auth" jar: just the interceptor + its JWT libs, with
+                             gRPC relocated (not bundled) to Spark Connect's namespace. Kept apart
+                             from the main "-all" jar, which relocates gRPC differently. -->
+                        <configuration>
+                            <shadedArtifactAttached>true</shadedArtifactAttached>
+                            <shadedClassifierName>connect-auth</shadedClassifierName>
+                            <createDependencyReducedPom>false</createDependencyReducedPom>
+                            <artifactSet>
+                                <includes>
+                                    <include>${project.groupId}:${project.artifactId}</include>
+                                    <include>com.auth0:java-jwt</include>
+                                    <include>com.auth0:jwks-rsa</include>
+                                </includes>
+                            </artifactSet>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>${project.groupId}:${project.artifactId}</artifact>
+                                    <includes>
+                                        <include>io/armadaproject/spark/connect/auth/**</include>
+                                    </includes>
+                                </filter>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>META-INF/MANIFEST.MF</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/versions/*/module-info.class</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                            <!-- Spark Connect shades gRPC under org.sparkproject.connect.grpc.*; the
+                                 interceptor registry casts to that shaded type. Relocate so our class
+                                 implements the namespace Spark Connect actually exposes at runtime. -->
+                            <relocations>
+                                <relocation>
+                                    <pattern>io.grpc.</pattern>
+                                    <shadedPattern>org.sparkproject.connect.grpc.</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/java/io/armadaproject/spark/connect/auth/AuthConfig.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/AuthConfig.java
@@ -23,14 +23,29 @@ import org.apache.spark.SparkConf;
  * keys are defined here so they have a single source of truth, and {@link #from(SparkConf)}
  * applies the read/trim/required rules in one place. Optional values are {@code null} when unset
  * or blank.
+ *
+ * <p>Kept as a plain final class (not a {@code record}) because the build matrix compiles Java at
+ * levels older than 16 for some Spark/Scala combinations.
  */
-record AuthConfig(String owner, String issuerUrl, String jwksUrl, String audience) {
+final class AuthConfig {
 
     private static final String PREFIX = "spark.armada.connect.";
     static final String OWNER    = PREFIX + "owner";
     static final String ISSUER   = PREFIX + "oidc.issuerUrl";
     static final String JWKS     = PREFIX + "oidc.jwksUrl";
     static final String AUDIENCE = PREFIX + "oidc.audience";
+
+    private final String owner;
+    private final String issuerUrl;
+    private final String jwksUrl;
+    private final String audience;
+
+    private AuthConfig(String owner, String issuerUrl, String jwksUrl, String audience) {
+        this.owner     = owner;
+        this.issuerUrl = issuerUrl;
+        this.jwksUrl   = jwksUrl;
+        this.audience  = audience;
+    }
 
     /** Read and validate the connect-auth configuration from a SparkConf. */
     static AuthConfig from(SparkConf conf) {
@@ -40,6 +55,11 @@ record AuthConfig(String owner, String issuerUrl, String jwksUrl, String audienc
                 optional(conf, JWKS),
                 optional(conf, AUDIENCE));
     }
+
+    String owner()     { return owner;     }
+    String issuerUrl() { return issuerUrl; }
+    String jwksUrl()   { return jwksUrl;   }
+    String audience()  { return audience;  }
 
     private static String required(SparkConf conf, String key) {
         String value = conf.get(key, null);

--- a/src/main/java/io/armadaproject/spark/connect/auth/AuthConfig.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/AuthConfig.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth;
+
+import org.apache.spark.SparkConf;
+
+/**
+ * Parsed and validated Spark Connect JWT-auth configuration. All {@code spark.armada.connect.*}
+ * keys are defined here so they have a single source of truth, and {@link #from(SparkConf)}
+ * applies the read/trim/required rules in one place. Optional values are {@code null} when unset
+ * or blank.
+ */
+record AuthConfig(String owner, String issuerUrl, String jwksUrl, String audience) {
+
+    private static final String PREFIX = "spark.armada.connect.";
+    static final String OWNER    = PREFIX + "owner";
+    static final String ISSUER   = PREFIX + "oidc.issuerUrl";
+    static final String JWKS     = PREFIX + "oidc.jwksUrl";
+    static final String AUDIENCE = PREFIX + "oidc.audience";
+
+    /** Read and validate the connect-auth configuration from a SparkConf. */
+    static AuthConfig from(SparkConf conf) {
+        return new AuthConfig(
+                required(conf, OWNER),
+                required(conf, ISSUER),
+                optional(conf, JWKS),
+                optional(conf, AUDIENCE));
+    }
+
+    private static String required(SparkConf conf, String key) {
+        String value = conf.get(key, null);
+        if (value == null || value.isBlank()) {
+            throw new IllegalStateException(key + " must be set");
+        }
+        return value.trim();
+    }
+
+    private static String optional(SparkConf conf, String key) {
+        String value = conf.get(key, null);
+        return (value == null || value.isBlank()) ? null : value.trim();
+    }
+}

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
@@ -39,8 +39,6 @@ public class JwtAuthInterceptor implements ServerInterceptor {
     private final JwtValidator validator;
     private final String owner;
 
-    static final String CONF_OWNER = "spark.armada.connect.owner";
-
     /**
      * No-arg constructor used by Spark Connect's interceptor registry: it instantiates
      * {@code spark.connect.grpc.interceptor.classes} via the default constructor only, so config
@@ -54,20 +52,19 @@ public class JwtAuthInterceptor implements ServerInterceptor {
         SparkEnv env = SparkEnv.get();
         if (env == null) {
             throw new IllegalStateException(
-                    "SparkEnv is not initialized; cannot read " + CONF_OWNER);
+                    "SparkEnv is not initialized; cannot read " + AuthConfig.OWNER);
         }
         return env.conf();
     }
 
-    /** Reads the owner from an explicit SparkConf (used by the no-arg ctor and tests). */
+    /** Reads config from an explicit SparkConf (used by the no-arg ctor and tests). */
     public JwtAuthInterceptor(SparkConf conf) {
-        String configuredOwner = conf.get(CONF_OWNER, null);
-        if (configuredOwner == null || configuredOwner.isBlank()) {
-            throw new IllegalStateException(
-                    CONF_OWNER + " must be set to use JwtAuthInterceptor");
-        }
-        this.owner = configuredOwner.trim();
-        this.validator = new JwtValidator(conf);
+        this(AuthConfig.from(conf));
+    }
+
+    JwtAuthInterceptor(AuthConfig cfg) {
+        this.owner = cfg.owner(); // already required and trimmed by AuthConfig
+        this.validator = new JwtValidator(cfg);
         LOG.info("JwtAuthInterceptor initialized: owner={}", owner);
     }
 
@@ -75,7 +72,7 @@ public class JwtAuthInterceptor implements ServerInterceptor {
     JwtAuthInterceptor(JwtValidator validator, String owner) {
         if (owner == null || owner.isBlank()) {
             throw new IllegalStateException(
-                    "owner must not be null or blank; set " + CONF_OWNER);
+                    "owner must not be null or blank; set " + AuthConfig.OWNER);
         }
         this.validator = validator;
         this.owner = owner.trim();

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
@@ -87,7 +87,7 @@ public class JwtAuthInterceptor implements ServerInterceptor {
 
         // Identity is the IdP-assigned `sub` claim (immutable, not self-assertable).
         String identity = jwt.getSubject();
-        if (identity == null) {
+        if (identity == null || identity.isBlank()) {
             return reject(call, Status.UNAUTHENTICATED, "Token has no subject claim");
         }
         if (!owner.equals(identity)) {
@@ -104,7 +104,8 @@ public class JwtAuthInterceptor implements ServerInterceptor {
         if (header.length() < BEARER_PREFIX.length()) return null;
         String prefix = header.substring(0, BEARER_PREFIX.length());
         if (!prefix.equalsIgnoreCase(BEARER_PREFIX)) return null;
-        return header.substring(BEARER_PREFIX.length()).trim();
+        String token = header.substring(BEARER_PREFIX.length()).trim();
+        return token.isEmpty() ? null : token;
     }
 
     private static <ReqT, RespT> ServerCall.Listener<ReqT> reject(

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
@@ -47,7 +47,7 @@ public class JwtAuthInterceptor implements ServerInterceptor {
             throw new IllegalStateException(
                     CONF_OWNER + " must be set to use JwtAuthInterceptor");
         }
-        this.owner = configuredOwner;
+        this.owner = configuredOwner.trim();
         this.validator = new JwtValidator(conf);
         LOG.info("JwtAuthInterceptor initialized: owner={}", owner);
     }
@@ -59,7 +59,7 @@ public class JwtAuthInterceptor implements ServerInterceptor {
                     "owner must not be null or blank; set " + CONF_OWNER);
         }
         this.validator = validator;
-        this.owner = owner;
+        this.owner = owner.trim();
     }
 
     @Override

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
@@ -24,6 +24,7 @@ import io.grpc.ServerCallHandler;
 import io.grpc.ServerInterceptor;
 import io.grpc.Status;
 import org.apache.spark.SparkConf;
+import org.apache.spark.SparkEnv;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -40,7 +41,25 @@ public class JwtAuthInterceptor implements ServerInterceptor {
 
     static final String CONF_OWNER = "spark.armada.connect.owner";
 
-    /** Reflection-friendly constructor. Reads the owner from the SparkConf. */
+    /**
+     * No-arg constructor used by Spark Connect's interceptor registry: it instantiates
+     * {@code spark.connect.grpc.interceptor.classes} via the default constructor only, so config
+     * is read from the active {@link SparkConf} obtained from {@link SparkEnv}.
+     */
+    public JwtAuthInterceptor() {
+        this(activeConf());
+    }
+
+    private static SparkConf activeConf() {
+        SparkEnv env = SparkEnv.get();
+        if (env == null) {
+            throw new IllegalStateException(
+                    "SparkEnv is not initialized; cannot read " + CONF_OWNER);
+        }
+        return env.conf();
+    }
+
+    /** Reads the owner from an explicit SparkConf (used by the no-arg ctor and tests). */
     public JwtAuthInterceptor(SparkConf conf) {
         String configuredOwner = conf.get(CONF_OWNER, null);
         if (configuredOwner == null || configuredOwner.isBlank()) {

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtAuthInterceptor.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth;
+
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import io.grpc.Metadata;
+import io.grpc.ServerCall;
+import io.grpc.ServerCallHandler;
+import io.grpc.ServerInterceptor;
+import io.grpc.Status;
+import org.apache.spark.SparkConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JwtAuthInterceptor implements ServerInterceptor {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JwtAuthInterceptor.class);
+
+    private static final Metadata.Key<String> AUTH_KEY =
+            Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER);
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtValidator validator;
+    private final String owner;
+
+    static final String CONF_OWNER = "spark.armada.connect.owner";
+
+    /** Reflection-friendly constructor. Reads the owner from the SparkConf. */
+    public JwtAuthInterceptor(SparkConf conf) {
+        String configuredOwner = conf.get(CONF_OWNER, null);
+        if (configuredOwner == null || configuredOwner.isBlank()) {
+            throw new IllegalStateException(
+                    CONF_OWNER + " must be set to use JwtAuthInterceptor");
+        }
+        this.owner = configuredOwner;
+        this.validator = new JwtValidator(conf);
+        LOG.info("JwtAuthInterceptor initialized: owner={}", owner);
+    }
+
+    /** Package-private constructor for tests. */
+    JwtAuthInterceptor(JwtValidator validator, String owner) {
+        if (owner == null || owner.isBlank()) {
+            throw new IllegalStateException(
+                    "owner must not be null or blank; set " + CONF_OWNER);
+        }
+        this.validator = validator;
+        this.owner = owner;
+    }
+
+    @Override
+    public <ReqT, RespT> ServerCall.Listener<ReqT> interceptCall(
+            ServerCall<ReqT, RespT> call,
+            Metadata headers,
+            ServerCallHandler<ReqT, RespT> next) {
+
+        String authHeader = headers.get(AUTH_KEY);
+        if (authHeader == null) {
+            return reject(call, Status.UNAUTHENTICATED, "Missing Authorization header");
+        }
+        String token = stripBearer(authHeader);
+        if (token == null) {
+            return reject(call, Status.UNAUTHENTICATED, "Authorization header is not a bearer token");
+        }
+
+        DecodedJWT jwt;
+        try {
+            jwt = validator.verify(token);
+        } catch (JWTVerificationException e) {
+            LOG.debug("JWT verification failed: {}", e.getMessage());
+            return reject(call, Status.UNAUTHENTICATED, "JWT verification failed");
+        }
+
+        // Identity is the IdP-assigned `sub` claim (immutable, not self-assertable).
+        String identity = jwt.getSubject();
+        if (identity == null) {
+            return reject(call, Status.UNAUTHENTICATED, "Token has no subject claim");
+        }
+        if (!owner.equals(identity)) {
+            LOG.warn("Access denied: subject '{}' does not match owner '{}'", identity, owner);
+            return reject(call, Status.PERMISSION_DENIED,
+                    "Caller is not the owner of this Spark Connect server");
+        }
+
+        LOG.debug("Authenticated request from owner '{}'", identity);
+        return next.startCall(call, headers);
+    }
+
+    private static String stripBearer(String header) {
+        if (header.length() < BEARER_PREFIX.length()) return null;
+        String prefix = header.substring(0, BEARER_PREFIX.length());
+        if (!prefix.equalsIgnoreCase(BEARER_PREFIX)) return null;
+        return header.substring(BEARER_PREFIX.length()).trim();
+    }
+
+    private static <ReqT, RespT> ServerCall.Listener<ReqT> reject(
+            ServerCall<ReqT, RespT> call, Status status, String message) {
+        call.close(status.withDescription(message), new Metadata());
+        return new ServerCall.Listener<ReqT>() {};
+    }
+}

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth;
+
+import com.auth0.jwk.JwkProvider;
+import com.auth0.jwk.JwkProviderBuilder;
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.auth0.jwt.exceptions.JWTVerificationException;
+import com.auth0.jwt.interfaces.DecodedJWT;
+import com.auth0.jwt.interfaces.RSAKeyProvider;
+import com.auth0.jwt.interfaces.Verification;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import org.apache.spark.SparkConf;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URL;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.security.interfaces.RSAPrivateKey;
+import java.security.interfaces.RSAPublicKey;
+import java.time.Duration;
+import java.util.concurrent.TimeUnit;
+
+public class JwtValidator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(JwtValidator.class);
+
+    private final JWTVerifier verifier;
+    private final String issuerUrl;
+    private final String audience;
+
+    private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Package-private constructor for tests: pass a fully-built verifier. */
+    JwtValidator(JWTVerifier verifier, String issuerUrl, String audience) {
+        this.verifier  = verifier;
+        this.issuerUrl = issuerUrl;
+        this.audience  = audience;
+    }
+
+    static final String CONF_ISSUER   = "spark.armada.connect.oidc.issuerUrl";
+    static final String CONF_JWKS     = "spark.armada.connect.oidc.jwksUrl";
+    static final String CONF_AUDIENCE = "spark.armada.connect.oidc.audience";
+
+    /** Reflection-friendly constructor. Reads all configuration from the SparkConf. */
+    public JwtValidator(SparkConf conf) {
+        String issuer = conf.get(CONF_ISSUER, null);
+        if (issuer == null || issuer.isBlank()) {
+            throw new IllegalStateException(CONF_ISSUER + " must be set");
+        }
+        String jwksOverride = conf.get(CONF_JWKS, null);
+        String aud          = conf.get(CONF_AUDIENCE, null);
+
+        String jwksUrl = resolveJwksUrl(issuer, jwksOverride);
+
+        JwkProvider jwkProvider;
+        try {
+            jwkProvider = new JwkProviderBuilder(new URL(jwksUrl))
+                    .cached(10, 24, TimeUnit.HOURS)
+                    .rateLimited(10, 1, TimeUnit.MINUTES)
+                    .timeouts(5_000, 5_000)  // connect, read; in milliseconds
+                    .build();
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException("Invalid jwks URL: " + jwksUrl, e);
+        }
+
+        Algorithm algorithm = Algorithm.RSA256(new RSAKeyProviderFromJwks(jwkProvider));
+        Verification builder = JWT.require(algorithm).withIssuer(issuer);
+        if (aud != null && !aud.isBlank()) {
+            builder.withAudience(aud);
+        }
+
+        this.verifier  = builder.build();
+        this.issuerUrl = issuer;
+        this.audience  = aud;
+        LOG.info("JwtValidator initialized: issuer={}, jwks={}, audience={}",
+                issuer, jwksUrl, aud == null ? "<none>" : aud);
+    }
+
+    public DecodedJWT verify(String token) throws JWTVerificationException {
+        return verifier.verify(token);
+    }
+
+    public String issuerUrl() { return issuerUrl; }
+    public String audience()  { return audience;  }
+
+    /**
+     * Resolve the JWKS endpoint URL. Returns {@code overrideJwksUrl} when set, otherwise
+     * fetches {@code <issuer>/.well-known/openid-configuration} and reads its
+     * {@code jwks_uri} field.
+     */
+    static String resolveJwksUrl(String issuerUrl, String overrideJwksUrl) {
+        if (overrideJwksUrl != null && !overrideJwksUrl.isBlank()) {
+            return overrideJwksUrl;
+        }
+        String discoveryUrl = trimTrailingSlash(issuerUrl) + "/.well-known/openid-configuration";
+        try {
+            HttpClient client = HttpClient.newBuilder()
+                    .connectTimeout(Duration.ofSeconds(5))
+                    .build();
+            HttpRequest req = HttpRequest.newBuilder(URI.create(discoveryUrl))
+                    .timeout(Duration.ofSeconds(10))
+                    .header("Accept", "application/json")
+                    .GET()
+                    .build();
+            HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            if (resp.statusCode() / 100 != 2) {
+                throw new IllegalStateException(
+                        "OIDC discovery returned HTTP " + resp.statusCode() + " from " + discoveryUrl);
+            }
+            return parseJwksUri(resp.body());
+        } catch (IOException e) {
+            throw new IllegalStateException("OIDC discovery failed for " + discoveryUrl, e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("OIDC discovery interrupted for " + discoveryUrl, e);
+        }
+    }
+
+    static String parseJwksUri(String discoveryJson) {
+        try {
+            JsonNode root = MAPPER.readTree(discoveryJson);
+            JsonNode field = root.get("jwks_uri");
+            if (field == null || !field.isTextual() || field.asText().isBlank()) {
+                throw new IllegalStateException("OIDC discovery doc has no jwks_uri");
+            }
+            return field.asText();
+        } catch (IOException e) {
+            throw new IllegalStateException("Failed to parse OIDC discovery doc", e);
+        }
+    }
+
+    private static String trimTrailingSlash(String s) {
+        return (s != null && s.endsWith("/")) ? s.substring(0, s.length() - 1) : s;
+    }
+
+    private static final class RSAKeyProviderFromJwks implements RSAKeyProvider {
+        private final JwkProvider jwkProvider;
+        RSAKeyProviderFromJwks(JwkProvider jwkProvider) {
+            this.jwkProvider = jwkProvider;
+        }
+
+        @Override
+        public RSAPublicKey getPublicKeyById(String keyId) {
+            try {
+                return (RSAPublicKey) jwkProvider.get(keyId).getPublicKey();
+            } catch (Exception e) {
+                throw new JWTVerificationException(
+                        "Failed to fetch public key for kid=" + keyId, e);
+            }
+        }
+
+        @Override public RSAPrivateKey getPrivateKey() { return null; }
+        @Override public String getPrivateKeyId() { return null; }
+    }
+}

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -85,7 +85,7 @@ public class JwtValidator {
         }
 
         String jwksUrl = resolveJwksUrl(issuer, jwksOverride);
-        requireHttps(jwksUrl);
+        requireHttps(jwksUrl, "JWKS URL");
 
         JwkProvider jwkProvider;
         try {
@@ -127,7 +127,18 @@ public class JwtValidator {
         if (overrideJwksUrl != null && !overrideJwksUrl.isBlank()) {
             return overrideJwksUrl;
         }
+        // Discovery fetches over the network, so the issuer itself must be tamper-resistant.
+        requireHttps(issuerUrl, "OIDC issuer URL");
         String discoveryUrl = trimTrailingSlash(issuerUrl) + "/.well-known/openid-configuration";
+        return fetchJwksUri(discoveryUrl);
+    }
+
+    /**
+     * Fetch an OIDC discovery document and return its {@code jwks_uri}. Package-private so the
+     * networked behavior (redirects, non-2xx, malformed body) can be exercised against a local
+     * HTTP server in tests; scheme enforcement lives in the callers.
+     */
+    static String fetchJwksUri(String discoveryUrl) {
         try {
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(Duration.ofSeconds(5))
@@ -170,19 +181,19 @@ public class JwtValidator {
     }
 
     /**
-     * Reject non-HTTPS JWKS URLs. Fetching signing keys over plaintext would let a
-     * man-in-the-middle substitute keys and forge tokens, defeating verification.
+     * Reject non-HTTPS URLs. Fetching discovery docs or signing keys over plaintext would
+     * let a man-in-the-middle substitute keys and forge tokens, defeating verification.
      */
-    private static void requireHttps(String jwksUrl) {
+    private static void requireHttps(String url, String label) {
         String scheme;
         try {
-            scheme = URI.create(jwksUrl).getScheme();
+            scheme = URI.create(url).getScheme();
         } catch (IllegalArgumentException e) {
-            throw new IllegalStateException("Invalid jwks URL: " + jwksUrl, e);
+            throw new IllegalStateException("Invalid " + label + ": " + url, e);
         }
         if (!"https".equalsIgnoreCase(scheme)) {
             throw new IllegalStateException(
-                    "JWKS URL must use https to prevent key-substitution attacks: " + jwksUrl);
+                    label + " must use https to prevent key-substitution attacks: " + url);
         }
     }
 

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -159,12 +159,7 @@ public class JwtValidator {
             // Cap the body so a hostile/misconfigured endpoint can't OOM us during startup.
             String body;
             try (InputStream in = resp.body()) {
-                byte[] bytes = in.readNBytes((int) MAX_DISCOVERY_BYTES + 1);
-                if (bytes.length > MAX_DISCOVERY_BYTES) {
-                    throw new IllegalStateException("OIDC discovery document from " + discoveryUrl
-                            + " exceeds " + MAX_DISCOVERY_BYTES + " bytes");
-                }
-                body = new String(bytes, StandardCharsets.UTF_8);
+                body = readDiscoveryBody(in, discoveryUrl);
             }
             return parseJwksUri(body);
         } catch (IOException e) {
@@ -173,6 +168,19 @@ public class JwtValidator {
             Thread.currentThread().interrupt();
             throw new IllegalStateException("OIDC discovery interrupted for " + discoveryUrl, e);
         }
+    }
+
+    /**
+     * Read a discovery body, enforcing {@link #MAX_DISCOVERY_BYTES}. Package-private so the cap is
+     * unit-testable directly, without streaming a large body through the JDK HTTP client.
+     */
+    static String readDiscoveryBody(InputStream in, String sourceUrl) throws IOException {
+        byte[] bytes = in.readNBytes((int) MAX_DISCOVERY_BYTES + 1);
+        if (bytes.length > MAX_DISCOVERY_BYTES) {
+            throw new IllegalStateException(
+                    "OIDC discovery document from " + sourceUrl + " exceeds " + MAX_DISCOVERY_BYTES + " bytes");
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
     }
 
     static String parseJwksUri(String discoveryJson) {

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -95,6 +95,16 @@ public class JwtValidator {
         String aud = cfg.audience(); // null when unset/blank (normalized by AuthConfig)
         if (aud != null) {
             builder.withAudience(aud);
+        } else {
+            // Without an audience constraint, any token the issuer minted for any relying party is
+            // accepted as long as its `sub` matches the owner. Set spark.armada.connect.oidc.audience
+            // to bind tokens to this server.
+            LOG.warn(
+                    "{} is not set: tokens for ANY audience issued by {} will be accepted. "
+                            + "Set {} to restrict tokens to this server.",
+                    AuthConfig.AUDIENCE,
+                    issuer,
+                    AuthConfig.AUDIENCE);
         }
 
         this.verifier  = builder.build();

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -29,7 +29,6 @@ import com.auth0.jwt.interfaces.Verification;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
-import org.apache.spark.SparkConf;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -67,33 +66,14 @@ public class JwtValidator {
         this.audience  = audience;
     }
 
-    static final String CONF_ISSUER   = "spark.armada.connect.oidc.issuerUrl";
-    static final String CONF_JWKS     = "spark.armada.connect.oidc.jwksUrl";
-    static final String CONF_AUDIENCE = "spark.armada.connect.oidc.audience";
-
-    /** Reflection-friendly constructor. Reads all configuration from the SparkConf. */
-    public JwtValidator(SparkConf conf) {
-        String issuer = conf.get(CONF_ISSUER, null);
-        if (issuer == null || issuer.isBlank()) {
-            throw new IllegalStateException(CONF_ISSUER + " must be set");
-        }
-        issuer = issuer.trim(); // tolerate stray whitespace from CLI/YAML templating
+    /** Builds the verifier from already-parsed {@link AuthConfig} (issuer/jwks/audience). */
+    JwtValidator(AuthConfig cfg) {
+        String issuer = cfg.issuerUrl();
         // The issuer is the trust anchor (matched against the token's `iss`); require https
         // regardless of how the JWKS URL is sourced, so an http issuer can never pass silently.
         requireHttps(issuer, "OIDC issuer URL");
-        String jwksOverride = conf.get(CONF_JWKS, null);
-        if (jwksOverride != null) {
-            jwksOverride = jwksOverride.trim();
-        }
-        String aud = conf.get(CONF_AUDIENCE, null);
-        if (aud != null) {
-            aud = aud.trim();
-            if (aud.isBlank()) {
-                aud = null; // treat blank as unset, so audience() and logs match enforcement
-            }
-        }
 
-        String jwksUrl = resolveJwksUrl(issuer, jwksOverride);
+        String jwksUrl = resolveJwksUrl(issuer, cfg.jwksUrl());
         requireHttps(jwksUrl, "JWKS URL");
 
         JwkProvider jwkProvider;
@@ -112,7 +92,8 @@ public class JwtValidator {
         // a token minted without `exp` would otherwise be accepted forever.
         Verification builder =
                 JWT.require(algorithm).withIssuer(issuer).withClaimPresence(RegisteredClaims.EXPIRES_AT);
-        if (aud != null && !aud.isBlank()) {
+        String aud = cfg.audience(); // null when unset/blank (normalized by AuthConfig)
+        if (aud != null) {
             builder.withAudience(aud);
         }
 

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -85,6 +85,7 @@ public class JwtValidator {
         }
 
         String jwksUrl = resolveJwksUrl(issuer, jwksOverride);
+        requireHttps(jwksUrl);
 
         JwkProvider jwkProvider;
         try {
@@ -130,6 +131,7 @@ public class JwtValidator {
         try {
             HttpClient client = HttpClient.newBuilder()
                     .connectTimeout(Duration.ofSeconds(5))
+                    .followRedirects(HttpClient.Redirect.NORMAL) // follow http->https & aliases, never downgrade
                     .build();
             HttpRequest req = HttpRequest.newBuilder(URI.create(discoveryUrl))
                     .timeout(Duration.ofSeconds(10))
@@ -165,6 +167,23 @@ public class JwtValidator {
 
     private static String trimTrailingSlash(String s) {
         return (s != null && s.endsWith("/")) ? s.substring(0, s.length() - 1) : s;
+    }
+
+    /**
+     * Reject non-HTTPS JWKS URLs. Fetching signing keys over plaintext would let a
+     * man-in-the-middle substitute keys and forge tokens, defeating verification.
+     */
+    private static void requireHttps(String jwksUrl) {
+        String scheme;
+        try {
+            scheme = URI.create(jwksUrl).getScheme();
+        } catch (IllegalArgumentException e) {
+            throw new IllegalStateException("Invalid jwks URL: " + jwksUrl, e);
+        }
+        if (!"https".equalsIgnoreCase(scheme)) {
+            throw new IllegalStateException(
+                    "JWKS URL must use https to prevent key-substitution attacks: " + jwksUrl);
+        }
     }
 
     private static final class RSAKeyProviderFromJwks implements RSAKeyProvider {

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -20,6 +20,7 @@ import com.auth0.jwk.JwkProvider;
 import com.auth0.jwk.JwkProviderBuilder;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.JWTVerifier;
+import com.auth0.jwt.RegisteredClaims;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.auth0.jwt.exceptions.JWTVerificationException;
 import com.auth0.jwt.interfaces.DecodedJWT;
@@ -33,12 +34,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.net.http.HttpClient;
 import java.net.http.HttpRequest;
 import java.net.http.HttpResponse;
+import java.nio.charset.StandardCharsets;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
 import java.time.Duration;
@@ -53,6 +56,9 @@ public class JwtValidator {
     private final String audience;
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
+
+    /** Upper bound on an OIDC discovery document; real docs are a few KB. */
+    private static final long MAX_DISCOVERY_BYTES = 1_048_576L; // 1 MiB
 
     /** Package-private constructor for tests: pass a fully-built verifier. */
     JwtValidator(JWTVerifier verifier, String issuerUrl, String audience) {
@@ -72,6 +78,9 @@ public class JwtValidator {
             throw new IllegalStateException(CONF_ISSUER + " must be set");
         }
         issuer = issuer.trim(); // tolerate stray whitespace from CLI/YAML templating
+        // The issuer is the trust anchor (matched against the token's `iss`); require https
+        // regardless of how the JWKS URL is sourced, so an http issuer can never pass silently.
+        requireHttps(issuer, "OIDC issuer URL");
         String jwksOverride = conf.get(CONF_JWKS, null);
         if (jwksOverride != null) {
             jwksOverride = jwksOverride.trim();
@@ -99,7 +108,10 @@ public class JwtValidator {
         }
 
         Algorithm algorithm = Algorithm.RSA256(new RSAKeyProviderFromJwks(jwkProvider));
-        Verification builder = JWT.require(algorithm).withIssuer(issuer);
+        // Require `exp` to be present: java-jwt only enforces expiry when the claim exists, so
+        // a token minted without `exp` would otherwise be accepted forever.
+        Verification builder =
+                JWT.require(algorithm).withIssuer(issuer).withClaimPresence(RegisteredClaims.EXPIRES_AT);
         if (aud != null && !aud.isBlank()) {
             builder.withAudience(aud);
         }
@@ -127,8 +139,7 @@ public class JwtValidator {
         if (overrideJwksUrl != null && !overrideJwksUrl.isBlank()) {
             return overrideJwksUrl;
         }
-        // Discovery fetches over the network, so the issuer itself must be tamper-resistant.
-        requireHttps(issuerUrl, "OIDC issuer URL");
+        // Issuer https is enforced unconditionally by the constructor before we get here.
         String discoveryUrl = trimTrailingSlash(issuerUrl) + "/.well-known/openid-configuration";
         return fetchJwksUri(discoveryUrl);
     }
@@ -149,12 +160,22 @@ public class JwtValidator {
                     .header("Accept", "application/json")
                     .GET()
                     .build();
-            HttpResponse<String> resp = client.send(req, HttpResponse.BodyHandlers.ofString());
+            HttpResponse<InputStream> resp = client.send(req, HttpResponse.BodyHandlers.ofInputStream());
             if (resp.statusCode() / 100 != 2) {
                 throw new IllegalStateException(
                         "OIDC discovery returned HTTP " + resp.statusCode() + " from " + discoveryUrl);
             }
-            return parseJwksUri(resp.body());
+            // Cap the body so a hostile/misconfigured endpoint can't OOM us during startup.
+            String body;
+            try (InputStream in = resp.body()) {
+                byte[] bytes = in.readNBytes((int) MAX_DISCOVERY_BYTES + 1);
+                if (bytes.length > MAX_DISCOVERY_BYTES) {
+                    throw new IllegalStateException("OIDC discovery document from " + discoveryUrl
+                            + " exceeds " + MAX_DISCOVERY_BYTES + " bytes");
+                }
+                body = new String(bytes, StandardCharsets.UTF_8);
+            }
+            return parseJwksUri(body);
         } catch (IOException e) {
             throw new IllegalStateException("OIDC discovery failed for " + discoveryUrl, e);
         } catch (InterruptedException e) {

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -73,6 +73,9 @@ public class JwtValidator {
         }
         String jwksOverride = conf.get(CONF_JWKS, null);
         String aud          = conf.get(CONF_AUDIENCE, null);
+        if (aud != null && aud.isBlank()) {
+            aud = null; // treat blank as unset, so audience() and logs match enforcement
+        }
 
         String jwksUrl = resolveJwksUrl(issuer, jwksOverride);
 

--- a/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
+++ b/src/main/java/io/armadaproject/spark/connect/auth/JwtValidator.java
@@ -71,10 +71,17 @@ public class JwtValidator {
         if (issuer == null || issuer.isBlank()) {
             throw new IllegalStateException(CONF_ISSUER + " must be set");
         }
+        issuer = issuer.trim(); // tolerate stray whitespace from CLI/YAML templating
         String jwksOverride = conf.get(CONF_JWKS, null);
-        String aud          = conf.get(CONF_AUDIENCE, null);
-        if (aud != null && aud.isBlank()) {
-            aud = null; // treat blank as unset, so audience() and logs match enforcement
+        if (jwksOverride != null) {
+            jwksOverride = jwksOverride.trim();
+        }
+        String aud = conf.get(CONF_AUDIENCE, null);
+        if (aud != null) {
+            aud = aud.trim();
+            if (aud.isBlank()) {
+                aud = null; // treat blank as unset, so audience() and logs match enforcement
+            }
         }
 
         String jwksUrl = resolveJwksUrl(issuer, jwksOverride);

--- a/src/test/scala/io/armadaproject/spark/connect/auth/AuthConfigSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/AuthConfigSuite.scala
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth
+
+import org.apache.spark.SparkConf
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class AuthConfigSuite extends AnyFunSuite with Matchers {
+
+  private def conf(pairs: (String, String)*): SparkConf = {
+    val c = new SparkConf(false)
+    pairs.foreach { case (k, v) => c.set(k, v) }
+    c
+  }
+
+  test("throws when owner is missing") {
+    an[IllegalStateException] should be thrownBy AuthConfig.from(
+      conf("spark.armada.connect.oidc.issuerUrl" -> "https://idp.test/")
+    )
+  }
+
+  test("throws when issuer is missing") {
+    an[IllegalStateException] should be thrownBy AuthConfig.from(
+      conf("spark.armada.connect.owner" -> "alice@example.com")
+    )
+  }
+
+  test("throws when issuer is blank") {
+    an[IllegalStateException] should be thrownBy AuthConfig.from(
+      conf(
+        "spark.armada.connect.owner"          -> "alice@example.com",
+        "spark.armada.connect.oidc.issuerUrl" -> "  "
+      )
+    )
+  }
+
+  test("trims values and treats blank optionals as unset") {
+    val cfg = AuthConfig.from(
+      conf(
+        "spark.armada.connect.owner"          -> "  alice@example.com  ",
+        "spark.armada.connect.oidc.issuerUrl" -> "  https://idp.test/  ",
+        "spark.armada.connect.oidc.jwksUrl"   -> "   ",
+        "spark.armada.connect.oidc.audience"  -> "  spark-connect  "
+      )
+    )
+    cfg.owner shouldBe "alice@example.com"
+    cfg.issuerUrl shouldBe "https://idp.test/"
+    cfg.jwksUrl shouldBe null
+    cfg.audience shouldBe "spark-connect"
+  }
+
+  test("leaves optionals null when unset") {
+    val cfg = AuthConfig.from(
+      conf(
+        "spark.armada.connect.owner"          -> "alice@example.com",
+        "spark.armada.connect.oidc.issuerUrl" -> "https://idp.test/"
+      )
+    )
+    cfg.jwksUrl shouldBe null
+    cfg.audience shouldBe null
+  }
+}

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
@@ -184,6 +184,14 @@ class JwtAuthInterceptorSuite extends AnyFunSuite with Matchers {
     an[IllegalStateException] should be thrownBy new JwtAuthInterceptor(validatorFor(), "  ")
   }
 
+  test("exposes a public no-arg constructor for Spark Connect's interceptor registry") {
+    // Spark Connect instantiates spark.connect.grpc.interceptor.classes by finding a
+    // zero-arg constructor; a SparkConf-only constructor is not used. Guard that contract.
+    val ctor = classOf[JwtAuthInterceptor].getConstructors.find(_.getParameterCount == 0)
+    ctor.isDefined shouldBe true
+    java.lang.reflect.Modifier.isPublic(ctor.get.getModifiers) shouldBe true
+  }
+
   test("SparkConf constructor throws when owner is missing") {
     val conf = new SparkConf(false)
       .set("spark.armada.connect.oidc.issuerUrl", issuer)

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth
+
+import java.security.KeyPairGenerator
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.util.Date
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import io.grpc.{Metadata, ServerCall, ServerCallHandler, Status}
+import org.mockito.ArgumentCaptor
+import org.mockito.ArgumentMatchers.any
+import org.mockito.Mockito.{mock, never, verify}
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class JwtAuthInterceptorSuite extends AnyFunSuite with Matchers {
+
+  private val keyPair = {
+    val gen = KeyPairGenerator.getInstance("RSA")
+    gen.initialize(2048)
+    gen.generateKeyPair()
+  }
+  private val pub    = keyPair.getPublic.asInstanceOf[RSAPublicKey]
+  private val priv   = keyPair.getPrivate.asInstanceOf[RSAPrivateKey]
+  private val alg    = Algorithm.RSA256(pub, priv)
+  private val issuer = "https://idp.test/"
+
+  private def verifierFor()  = JWT.require(alg).withIssuer(issuer).build()
+  private def validatorFor() = new JwtValidator(verifierFor(), issuer, null)
+
+  private def tokenFor(subject: String) =
+    JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject(subject)
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+  private val AUTH_KEY =
+    Metadata.Key.of("Authorization", Metadata.ASCII_STRING_MARSHALLER)
+
+  private def runInterceptor(
+      interceptor: JwtAuthInterceptor,
+      headerValue: Option[String]
+  ): (ServerCall[String, String], ServerCallHandler[String, String]) = {
+    val call    = mock(classOf[ServerCall[String, String]])
+    val handler = mock(classOf[ServerCallHandler[String, String]])
+    val headers = new Metadata()
+    headerValue.foreach(v => headers.put(AUTH_KEY, v))
+    interceptor.interceptCall(call, headers, handler)
+    (call, handler)
+  }
+
+  test("rejects with UNAUTHENTICATED when Authorization header is missing") {
+    val interceptor     = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) = runInterceptor(interceptor, None)
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.UNAUTHENTICATED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
+  test("allows the call when the JWT subject matches the configured owner") {
+    val interceptor = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) =
+      runInterceptor(interceptor, Some("Bearer " + tokenFor("alice@example.com")))
+
+    verify(call, never()).close(any(), any())
+    verify(handler).startCall(any(), any())
+  }
+
+  test("rejects with PERMISSION_DENIED when the JWT subject does not match the owner") {
+    val interceptor = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) =
+      runInterceptor(interceptor, Some("Bearer " + tokenFor("eve@example.com")))
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.PERMISSION_DENIED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
+  test("rejects with UNAUTHENTICATED when Authorization header is not a bearer token") {
+    val interceptor     = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) = runInterceptor(interceptor, Some("Basic dXNlcjpwYXNz"))
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.UNAUTHENTICATED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
+  test("rejects with UNAUTHENTICATED when JWT signature is invalid") {
+    val wrongKeyPair = {
+      val gen = KeyPairGenerator.getInstance("RSA"); gen.initialize(2048); gen.generateKeyPair()
+    }
+    val wrongAlg = Algorithm.RSA256(
+      wrongKeyPair.getPublic.asInstanceOf[RSAPublicKey],
+      wrongKeyPair.getPrivate.asInstanceOf[RSAPrivateKey]
+    )
+    val tamperedToken = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(wrongAlg)
+
+    val interceptor     = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) = runInterceptor(interceptor, Some("Bearer " + tamperedToken))
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.UNAUTHENTICATED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
+  test("accepts the bearer prefix case-insensitively") {
+    val interceptor = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) =
+      runInterceptor(interceptor, Some("bearer " + tokenFor("alice@example.com")))
+
+    verify(call, never()).close(any(), any())
+    verify(handler).startCall(any(), any())
+  }
+
+  test("rejects with UNAUTHENTICATED when the token has no subject") {
+    val tokenWithoutSubject = JWT
+      .create()
+      .withIssuer(issuer)
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val interceptor     = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) = runInterceptor(interceptor, Some("Bearer " + tokenWithoutSubject))
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.UNAUTHENTICATED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
+  test("throws when owner is null") {
+    an[IllegalStateException] should be thrownBy new JwtAuthInterceptor(validatorFor(), null)
+  }
+
+  test("throws when owner is blank") {
+    an[IllegalStateException] should be thrownBy new JwtAuthInterceptor(validatorFor(), "  ")
+  }
+}

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
@@ -87,6 +87,15 @@ class JwtAuthInterceptorSuite extends AnyFunSuite with Matchers {
     verify(handler).startCall(any(), any())
   }
 
+  test("trims surrounding whitespace from the configured owner") {
+    val interceptor = new JwtAuthInterceptor(validatorFor(), "  alice@example.com  ")
+    val (call, handler) =
+      runInterceptor(interceptor, Some("Bearer " + tokenFor("alice@example.com")))
+
+    verify(call, never()).close(any(), any())
+    verify(handler).startCall(any(), any())
+  }
+
   test("rejects with PERMISSION_DENIED when the JWT subject does not match the owner") {
     val interceptor = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
     val (call, handler) =

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
@@ -108,6 +108,16 @@ class JwtAuthInterceptorSuite extends AnyFunSuite with Matchers {
     verify(handler, never()).startCall(any(), any())
   }
 
+  test("rejects with UNAUTHENTICATED when the bearer token is empty") {
+    val interceptor     = new JwtAuthInterceptor(validatorFor(), "alice@example.com")
+    val (call, handler) = runInterceptor(interceptor, Some("Bearer   "))
+
+    val statusCap = ArgumentCaptor.forClass(classOf[Status])
+    verify(call).close(statusCap.capture(), any(classOf[Metadata]))
+    statusCap.getValue.getCode shouldBe Status.UNAUTHENTICATED.getCode
+    verify(handler, never()).startCall(any(), any())
+  }
+
   test("rejects with UNAUTHENTICATED when JWT signature is invalid") {
     val wrongKeyPair = {
       val gen = KeyPairGenerator.getInstance("RSA"); gen.initialize(2048); gen.generateKeyPair()

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtAuthInterceptorSuite.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import io.grpc.{Metadata, ServerCall, ServerCallHandler, Status}
+import org.apache.spark.SparkConf
 import org.mockito.ArgumentCaptor
 import org.mockito.ArgumentMatchers.any
 import org.mockito.Mockito.{mock, never, verify}
@@ -162,5 +163,20 @@ class JwtAuthInterceptorSuite extends AnyFunSuite with Matchers {
 
   test("throws when owner is blank") {
     an[IllegalStateException] should be thrownBy new JwtAuthInterceptor(validatorFor(), "  ")
+  }
+
+  test("SparkConf constructor throws when owner is missing") {
+    val conf = new SparkConf(false)
+      .set("spark.armada.connect.oidc.issuerUrl", issuer)
+      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
+    an[IllegalStateException] should be thrownBy new JwtAuthInterceptor(conf)
+  }
+
+  test("SparkConf constructor builds when owner and issuer are set") {
+    val conf = new SparkConf(false)
+      .set("spark.armada.connect.owner", "alice@example.com")
+      .set("spark.armada.connect.oidc.issuerUrl", issuer)
+      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
+    noException should be thrownBy new JwtAuthInterceptor(conf)
   }
 }

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.armadaproject.spark.connect.auth
+
+import java.security.KeyPairGenerator
+import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
+import java.util.Date
+
+import com.auth0.jwt.JWT
+import com.auth0.jwt.algorithms.Algorithm
+import com.auth0.jwt.exceptions.JWTVerificationException
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+class JwtValidatorSuite extends AnyFunSuite with Matchers {
+
+  private val keyPair = {
+    val gen = KeyPairGenerator.getInstance("RSA")
+    gen.initialize(2048)
+    gen.generateKeyPair()
+  }
+  private val pub    = keyPair.getPublic.asInstanceOf[RSAPublicKey]
+  private val priv   = keyPair.getPrivate.asInstanceOf[RSAPrivateKey]
+  private val alg    = Algorithm.RSA256(pub, priv)
+  private val issuer = "https://idp.test/"
+
+  private def buildVerifier(audience: String = null) = {
+    val b = JWT.require(alg).withIssuer(issuer)
+    if (audience != null) b.withAudience(audience)
+    b.build()
+  }
+
+  test("verifies a fresh token signed with the matching key") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val validator = new JwtValidator(buildVerifier(), issuer, null)
+    val jwt       = validator.verify(token)
+    jwt.getSubject shouldBe "alice@example.com"
+  }
+
+  test("rejects a token with the wrong issuer") {
+    val token = JWT
+      .create()
+      .withIssuer("https://attacker.test/")
+      .withSubject("alice@example.com")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val validator = new JwtValidator(buildVerifier(), issuer, null)
+    a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+
+  test("rejects an expired token") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withExpiresAt(new Date(System.currentTimeMillis() - 60000))
+      .sign(alg)
+
+    val validator = new JwtValidator(buildVerifier(), issuer, null)
+    a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+
+  test("parseJwksUri extracts jwks_uri from an OIDC discovery doc") {
+    val body =
+      """{"issuer":"https://idp.test/","jwks_uri":"https://idp.test/jwks","other":"x"}"""
+    JwtValidator.parseJwksUri(body) shouldBe "https://idp.test/jwks"
+  }
+
+  test("parseJwksUri throws when jwks_uri is missing") {
+    val body = """{"issuer":"https://idp.test/"}"""
+    an[IllegalStateException] should be thrownBy JwtValidator.parseJwksUri(body)
+  }
+
+  test("accepts a token whose aud matches the configured audience") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withAudience("spark-connect")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val verifier  = JWT.require(alg).withIssuer(issuer).withAudience("spark-connect").build()
+    val validator = new JwtValidator(verifier, issuer, "spark-connect")
+    validator.verify(token).getSubject shouldBe "alice@example.com"
+  }
+
+  test("rejects a token whose aud does not match the configured audience") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withAudience("some-other-app")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val verifier  = JWT.require(alg).withIssuer(issuer).withAudience("spark-connect").build()
+    val validator = new JwtValidator(verifier, issuer, "spark-connect")
+    a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+
+  test("rejects a token with no aud when audience is required") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
+      .withExpiresAt(new Date(System.currentTimeMillis() + 60000))
+      .sign(alg)
+
+    val verifier  = JWT.require(alg).withIssuer(issuer).withAudience("spark-connect").build()
+    val validator = new JwtValidator(verifier, issuer, "spark-connect")
+    a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+}

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -153,39 +153,36 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
     a[JWTVerificationException] should be thrownBy validator.verify(token)
   }
 
-  test("SparkConf constructor throws when issuer is missing") {
-    an[IllegalStateException] should be thrownBy new JwtValidator(new SparkConf(false))
+  private def authConf(issuerUrl: String, jwksUrl: String = null): SparkConf = {
+    val c = new SparkConf(false)
+      .set("spark.armada.connect.owner", "alice@example.com")
+      .set("spark.armada.connect.oidc.issuerUrl", issuerUrl)
+    if (jwksUrl != null) c.set("spark.armada.connect.oidc.jwksUrl", jwksUrl)
+    c
   }
 
-  test("SparkConf constructor throws when issuer is blank") {
-    val conf = new SparkConf(false).set("spark.armada.connect.oidc.issuerUrl", "  ")
-    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  test("rejects a non-https jwksUrl") {
+    an[IllegalStateException] should be thrownBy new JwtValidator(
+      AuthConfig.from(authConf(issuer, "http://idp.test/jwks"))
+    )
   }
 
-  test("SparkConf constructor rejects a non-https jwksUrl") {
-    val conf = new SparkConf(false)
-      .set("spark.armada.connect.oidc.issuerUrl", issuer)
-      .set("spark.armada.connect.oidc.jwksUrl", "http://idp.test/jwks")
-    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  test("builds with an explicit jwksUrl (no discovery)") {
+    noException should be thrownBy new JwtValidator(
+      AuthConfig.from(authConf(issuer, "https://idp.test/jwks"))
+    )
   }
 
-  test("SparkConf constructor builds with an explicit jwksUrl (no discovery)") {
-    val conf = new SparkConf(false)
-      .set("spark.armada.connect.oidc.issuerUrl", issuer)
-      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
-    noException should be thrownBy new JwtValidator(conf)
+  test("rejects a non-https issuer when discovery is used") {
+    an[IllegalStateException] should be thrownBy new JwtValidator(
+      AuthConfig.from(authConf("http://idp.test/"))
+    )
   }
 
-  test("SparkConf constructor rejects a non-https issuer when discovery is used") {
-    val conf = new SparkConf(false).set("spark.armada.connect.oidc.issuerUrl", "http://idp.test/")
-    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
-  }
-
-  test("SparkConf constructor rejects a non-https issuer even with an explicit jwksUrl override") {
-    val conf = new SparkConf(false)
-      .set("spark.armada.connect.oidc.issuerUrl", "http://idp.test/")
-      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
-    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  test("rejects a non-https issuer even with an explicit jwksUrl override") {
+    an[IllegalStateException] should be thrownBy new JwtValidator(
+      AuthConfig.from(authConf("http://idp.test/", "https://idp.test/jwks"))
+    )
   }
 
   // --- networked discovery (fetchJwksUri) against a local HTTP server ---

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -16,6 +16,7 @@
  */
 package io.armadaproject.spark.connect.auth
 
+import java.io.ByteArrayInputStream
 import java.net.InetSocketAddress
 import java.nio.charset.StandardCharsets
 import java.security.KeyPairGenerator
@@ -243,12 +244,15 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
     }
   }
 
-  test("fetchJwksUri rejects a discovery document larger than the size cap") {
-    // One byte over the 1 MiB cap enforced by JwtValidator.MAX_DISCOVERY_BYTES.
-    val tooBig = "a" * (1048576 + 1)
-    withServer({ case `discoveryPath` => (200, Map.empty, tooBig) }) { base =>
-      val ex = the[IllegalStateException] thrownBy JwtValidator.fetchJwksUri(base + discoveryPath)
-      ex.getMessage should include("exceeds")
-    }
+  test("readDiscoveryBody rejects a body larger than the size cap") {
+    // One byte over the 1 MiB cap. Tested directly rather than through the JDK HTTP client, whose
+    // large-stream read trips an internal assertion on some JVMs (e.g. Java 11 under -ea).
+    val tooBig = new ByteArrayInputStream(("a" * (1048576 + 1)).getBytes(StandardCharsets.UTF_8))
+    val ex =
+      the[IllegalStateException] thrownBy JwtValidator.readDiscoveryBody(
+        tooBig,
+        "https://idp.test/d"
+      )
+    ex.getMessage should include("exceeds")
   }
 }

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -147,6 +147,13 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
     an[IllegalStateException] should be thrownBy new JwtValidator(conf)
   }
 
+  test("SparkConf constructor rejects a non-https jwksUrl") {
+    val conf = new SparkConf(false)
+      .set("spark.armada.connect.oidc.issuerUrl", issuer)
+      .set("spark.armada.connect.oidc.jwksUrl", "http://idp.test/jwks")
+    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  }
+
   test("SparkConf constructor builds with an explicit jwksUrl (no discovery)") {
     val conf = new SparkConf(false)
       .set("spark.armada.connect.oidc.issuerUrl", issuer)

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -23,6 +23,7 @@ import java.util.Date
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTVerificationException
+import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
@@ -131,5 +132,21 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
     val verifier  = JWT.require(alg).withIssuer(issuer).withAudience("spark-connect").build()
     val validator = new JwtValidator(verifier, issuer, "spark-connect")
     a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+
+  test("SparkConf constructor throws when issuer is missing") {
+    an[IllegalStateException] should be thrownBy new JwtValidator(new SparkConf(false))
+  }
+
+  test("SparkConf constructor throws when issuer is blank") {
+    val conf = new SparkConf(false).set("spark.armada.connect.oidc.issuerUrl", "  ")
+    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  }
+
+  test("SparkConf constructor builds with an explicit jwksUrl (no discovery)") {
+    val conf = new SparkConf(false)
+      .set("spark.armada.connect.oidc.issuerUrl", issuer)
+      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
+    noException should be thrownBy new JwtValidator(conf)
   }
 }

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -23,6 +23,7 @@ import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
 import java.util.Date
 
 import com.auth0.jwt.JWT
+import com.auth0.jwt.RegisteredClaims
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTVerificationException
 import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
@@ -43,7 +44,7 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
   private val issuer = "https://idp.test/"
 
   private def buildVerifier(audience: String = null) = {
-    val b = JWT.require(alg).withIssuer(issuer)
+    val b = JWT.require(alg).withIssuer(issuer).withClaimPresence(RegisteredClaims.EXPIRES_AT)
     if (audience != null) b.withAudience(audience)
     b.build()
   }
@@ -79,6 +80,17 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
       .withIssuer(issuer)
       .withSubject("alice@example.com")
       .withExpiresAt(new Date(System.currentTimeMillis() - 60000))
+      .sign(alg)
+
+    val validator = new JwtValidator(buildVerifier(), issuer, null)
+    a[JWTVerificationException] should be thrownBy validator.verify(token)
+  }
+
+  test("rejects a token with no exp claim") {
+    val token = JWT
+      .create()
+      .withIssuer(issuer)
+      .withSubject("alice@example.com")
       .sign(alg)
 
     val validator = new JwtValidator(buildVerifier(), issuer, null)
@@ -166,6 +178,13 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
 
   test("SparkConf constructor rejects a non-https issuer when discovery is used") {
     val conf = new SparkConf(false).set("spark.armada.connect.oidc.issuerUrl", "http://idp.test/")
+    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  }
+
+  test("SparkConf constructor rejects a non-https issuer even with an explicit jwksUrl override") {
+    val conf = new SparkConf(false)
+      .set("spark.armada.connect.oidc.issuerUrl", "http://idp.test/")
+      .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
     an[IllegalStateException] should be thrownBy new JwtValidator(conf)
   }
 

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -16,6 +16,8 @@
  */
 package io.armadaproject.spark.connect.auth
 
+import java.net.InetSocketAddress
+import java.nio.charset.StandardCharsets
 import java.security.KeyPairGenerator
 import java.security.interfaces.{RSAPrivateKey, RSAPublicKey}
 import java.util.Date
@@ -23,6 +25,7 @@ import java.util.Date
 import com.auth0.jwt.JWT
 import com.auth0.jwt.algorithms.Algorithm
 import com.auth0.jwt.exceptions.JWTVerificationException
+import com.sun.net.httpserver.{HttpExchange, HttpHandler, HttpServer}
 import org.apache.spark.SparkConf
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
@@ -159,5 +162,68 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
       .set("spark.armada.connect.oidc.issuerUrl", issuer)
       .set("spark.armada.connect.oidc.jwksUrl", "https://idp.test/jwks")
     noException should be thrownBy new JwtValidator(conf)
+  }
+
+  test("SparkConf constructor rejects a non-https issuer when discovery is used") {
+    val conf = new SparkConf(false).set("spark.armada.connect.oidc.issuerUrl", "http://idp.test/")
+    an[IllegalStateException] should be thrownBy new JwtValidator(conf)
+  }
+
+  // --- networked discovery (fetchJwksUri) against a local HTTP server ---
+
+  /** Start a throwaway loopback HTTP server, run `body` with its base URL, then stop it. */
+  private def withServer(routes: PartialFunction[String, (Int, Map[String, String], String)])(
+      body: String => Unit
+  ): Unit = {
+    val server = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0)
+    server.createContext(
+      "/",
+      new HttpHandler {
+        override def handle(ex: HttpExchange): Unit = {
+          val (code, headers, payload) =
+            routes.applyOrElse(
+              ex.getRequestURI.getPath,
+              (_: String) => (404, Map.empty[String, String], "")
+            )
+          headers.foreach { case (k, v) => ex.getResponseHeaders.add(k, v) }
+          val bytes = payload.getBytes(StandardCharsets.UTF_8)
+          // -1 length for redirects/empty bodies so no content is written.
+          ex.sendResponseHeaders(code, if (bytes.isEmpty) -1 else bytes.length.toLong)
+          if (bytes.nonEmpty) {
+            val os = ex.getResponseBody
+            os.write(bytes)
+            os.close()
+          }
+          ex.close()
+        }
+      }
+    )
+    server.start()
+    try body(s"http://127.0.0.1:${server.getAddress.getPort}")
+    finally server.stop(0)
+  }
+
+  private val discoveryPath = "/.well-known/openid-configuration"
+  private val discoveryDoc = """{"issuer":"https://idp.test/","jwks_uri":"https://idp.test/jwks"}"""
+
+  test("fetchJwksUri returns jwks_uri from a 200 discovery response") {
+    withServer({ case `discoveryPath` => (200, Map.empty, discoveryDoc) }) { base =>
+      JwtValidator.fetchJwksUri(base + discoveryPath) shouldBe "https://idp.test/jwks"
+    }
+  }
+
+  test("fetchJwksUri throws on a non-2xx discovery response") {
+    withServer({ case `discoveryPath` => (500, Map.empty, "boom") }) { base =>
+      an[IllegalStateException] should be thrownBy JwtValidator.fetchJwksUri(base + discoveryPath)
+    }
+  }
+
+  test("fetchJwksUri follows redirects during discovery") {
+    withServer({
+      case `discoveryPath`   => (302, Map("Location" -> "/real-discovery"), "")
+      case "/real-discovery" => (200, Map.empty, discoveryDoc)
+    }) { base =>
+      JwtValidator.fetchJwksUri(base + discoveryPath) shouldBe "https://idp.test/jwks"
+    }
   }
 }

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -93,6 +93,10 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
     an[IllegalStateException] should be thrownBy JwtValidator.parseJwksUri(body)
   }
 
+  test("parseJwksUri throws on malformed discovery JSON") {
+    an[IllegalStateException] should be thrownBy JwtValidator.parseJwksUri("not json")
+  }
+
   test("accepts a token whose aud matches the configured audience") {
     val token = JWT
       .create()

--- a/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
+++ b/src/test/scala/io/armadaproject/spark/connect/auth/JwtValidatorSuite.scala
@@ -242,4 +242,13 @@ class JwtValidatorSuite extends AnyFunSuite with Matchers {
       JwtValidator.fetchJwksUri(base + discoveryPath) shouldBe "https://idp.test/jwks"
     }
   }
+
+  test("fetchJwksUri rejects a discovery document larger than the size cap") {
+    // One byte over the 1 MiB cap enforced by JwtValidator.MAX_DISCOVERY_BYTES.
+    val tooBig = "a" * (1048576 + 1)
+    withServer({ case `discoveryPath` => (200, Map.empty, tooBig) }) { base =>
+      val ex = the[IllegalStateException] thrownBy JwtValidator.fetchJwksUri(base + discoveryPath)
+      ex.getMessage should include("exceeds")
+    }
+  }
 }


### PR DESCRIPTION
Related to https://github.com/armadaproject/armada-spark/issues/129

**What:** Adds an optional JWT bearer-token authentication layer for Spark Connect (gRPC), shipped as a standalone interceptor jar.

**Why:** Spark Connect's gRPC endpoint has no built-in authentication, so anyone who can reach the driver port can run code as the session owner. This validates an OIDC-issued JWT on every call and pins the session to a single configured identity, without touching the existing cluster-manager submission paths.

**Changes:**
- New Java library under `io.armadaproject.spark.connect.auth`: `JwtAuthInterceptor` (gRPC `ServerInterceptor`), `JwtValidator` (signature/claim validation + JWKS), and `AuthConfig` (config parsing).
- Validates RS256 signature, `iss`, required `exp`, and `aud` when configured; compares the token `sub` against the configured owner. Rejects missing/invalid tokens with `UNAUTHENTICATED` and owner mismatch with `PERMISSION_DENIED`.
- Resolves signing keys via OIDC discovery (`<issuer>/.well-known/openid-configuration`) or an explicit JWKS URL; both require `https`. JWKS fetches are cached, rate-limited, and time-bounded; discovery bodies are capped at 1 MiB.
- Four config keys: `spark.armada.connect.owner` (required), `spark.armada.connect.oidc.issuerUrl` (required), `spark.armada.connect.oidc.jwksUrl` and `spark.armada.connect.oidc.audience` (optional). When `audience` is unset, `aud` is not enforced and the driver logs a startup warning.
- Builds a separate `connect-auth` jar with `io.grpc` relocated to Spark Connect's `org.sparkproject.connect.grpc` namespace; `grpc-api` is inherited transitively so its version cannot drift from the client. `Dockerfile` ships the jar.
- Registered via `spark.connect.grpc.interceptor.classes`; documented in `README.md`.

**Tests:** 37 tests across `AuthConfigSuite`, `JwtValidatorSuite`, and `JwtAuthInterceptorSuite` covering config parsing, signature/issuer/expiry/audience validation, bearer parsing (case-insensitivity, blank/empty/malformed headers), owner match/mismatch, `https` enforcement, and OIDC discovery (success, non-2xx, redirect, malformed JSON, 1 MiB size cap).