### PR TITLE
fixed unit tests failing on internal builds

### DIFF
--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala
@@ -32,8 +32,15 @@ private[submit] object ConfigGenerator {
   val ENV_SPARK_CONF_DIR   = "SPARK_CONF_DIR"
 }
 
-private[submit] class ConfigGenerator(val prefix: String, val conf: SparkConf) {
-  private val confDir = Option(conf.getenv(ENV_SPARK_CONF_DIR))
+private[submit] class ConfigGenerator(
+    val prefix: String,
+    val conf: SparkConf,
+    envLookup: String => Option[String] = name => Option(System.getenv(name))
+) {
+  // Lookup precedence: caller-supplied env (defaults to System.getenv, but
+  // tests can inject a stub to keep their fixture independent of the env vars
+  // in existence.)
+  private val confDir = envLookup(ENV_SPARK_CONF_DIR)
     .orElse(conf.getOption("spark.home").map(dir => s"$dir/conf"))
 
   private val confFiles = getConfFiles

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/ConfigGeneratorSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/ConfigGeneratorSuite.scala
@@ -50,7 +50,7 @@ class ConfigGeneratorSuite extends AnyFunSuite with BeforeAndAfter {
   }
   test("Test annotations") {
     val expectedString = s"Map($prefix/spark-defaults.conf -> $configFileContents)"
-    val cg             = new ConfigGenerator(prefix, sparkConf)
+    val cg             = new ConfigGenerator(prefix, sparkConf, _ => None)
     val ann            = cg.getAnnotations
     assert(ann.toString == expectedString)
   }
@@ -70,9 +70,29 @@ class ConfigGeneratorSuite extends AnyFunSuite with BeforeAndAfter {
         |}
         |""".stripMargin
 
-    val cg  = new ConfigGenerator(prefix, sparkConf)
+    val cg  = new ConfigGenerator(prefix, sparkConf, _ => None)
     val vol = cg.getVolumes
     assert(vol.head.toProtoString == expectedString)
+  }
+
+  test("injected env takes precedence") {
+    val rogueDir = Files.createTempDirectory("rogue-spark-conf-")
+    Files.writeString(
+      rogueDir.resolve("rogue.conf"),
+      "rogue=true",
+      StandardOpenOption.CREATE
+    )
+    try {
+      val envWithRogue: String => Option[String] = {
+        case "SPARK_CONF_DIR" => Some(rogueDir.toString)
+        case _                => None
+      }
+      val cg = new ConfigGenerator(prefix, sparkConf, envWithRogue)
+      assert(cg.getAnnotations.keys.toSet == Set(s"$prefix/rogue.conf"))
+    } finally {
+      Files.deleteIfExists(rogueDir.resolve("rogue.conf"))
+      Files.deleteIfExists(rogueDir)
+    }
   }
 
   test("Test volume mounts") {
@@ -82,7 +102,7 @@ class ConfigGeneratorSuite extends AnyFunSuite with BeforeAndAfter {
         |mountPath: "${ConfigGenerator.REMOTE_CONF_DIR_NAME}"
         |""".stripMargin
 
-    val cg        = new ConfigGenerator(prefix, sparkConf)
+    val cg        = new ConfigGenerator(prefix, sparkConf, _ => None)
     val volMounts = cg.getVolumeMounts
     assert(volMounts.head.toProtoString == expectedString)
   }


### PR DESCRIPTION
## Summary

`ConfigGeneratorSuite` was failing for any developer with `SPARK_CONF_DIR` exported in their shell (e.g. in GR, the default points to `/opt/spark3/conf`). The production code was reading that env var unconditionally via `System.getenv`, so the test fixture's `tempDir/conf` was never consulted; it was the *fallback*, never the *primary* lookup. CI passed because the CI runner doesn't set `SPARK_CONF_DIR`.

This change makes the env-var lookup injectable so tests can stub it, while keeping production behavior identical.

## Changes

### `src/main/scala/org/apache/spark/deploy/armada/submit/ConfigGenerator.scala`

Add a defaulted constructor parameter `envLookup: String => Option[String]`, defaulting to `System.getenv`. Use it in the `confDir` resolution:


### `src/test/scala/org/apache/spark/deploy/armada/submit/ConfigGeneratorSuite.scala`
- Existing tests now pass `_ => None` as the env stub, fully isolating them from the host shell.