### PR TITLE
cap initial gang batch by gang cardinality

### DIFF
--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -575,6 +575,14 @@ private[spark] class ArmadaClusterManagerBackend(
 
   private[armada] def isReadyToAllocateMore: Boolean = modeHelper.isReadyToAllocateMore
 
+  /** Per-mode gang cardinality. Returns 0 once gang attributes have been captured (post-bootstrap)
+    * or in modes that don't use gang scheduling — in which case the allocator's batch size is the
+    * only per-tick cap. Pre-capture this is the size Armada will enforce on the gang, so the
+    * allocator must not submit more than this in a single tick or Armada rejects every job after
+    * the cardinality is exceeded.
+    */
+  private[armada] def getGangCardinality: Int = modeHelper.getGangCardinality
+
   /** Called when Armada signals a job is being preempted. Proactively start decommissioning.
     */
   private[armada] def onArmadaPreempting(jobId: String): Unit = {

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -575,12 +575,6 @@ private[spark] class ArmadaClusterManagerBackend(
 
   private[armada] def isReadyToAllocateMore: Boolean = modeHelper.isReadyToAllocateMore
 
-  /** Per-mode gang cardinality. Returns 0 once gang attributes have been captured (post-bootstrap)
-    * or in modes that don't use gang scheduling — in which case the allocator's batch size is the
-    * only per-tick cap. Pre-capture this is the size Armada will enforce on the gang, so the
-    * allocator must not submit more than this in a single tick or Armada rejects every job after
-    * the cardinality is exceeded.
-    */
   private[armada] def getGangCardinality: Int = modeHelper.getGangCardinality
 
   /** Called when Armada signals a job is being preempted. Proactively start decommissioning.

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
@@ -115,12 +115,6 @@ private[spark] class ArmadaExecutorAllocator(
               // This prevents scale-up executors from landing on a different cluster.
               val isInitialBatch = currentCount == 0 && pending == 0
               if (isInitialBatch || backend.isReadyToAllocateMore) {
-                // Pre-capture, Armada enforces the gang cardinality across the bootstrap batch:
-                // submitting more than `gangCardinality` jobs causes every job past that point to
-                // be rejected with "cannot submit more jobs to gang than specified in gang
-                // cardinality", which the allocator's retry loop then resubmits indefinitely.
-                // Cap by gangCardinality so the per-tick submission never overflows the gang.
-                // Post-capture, getGangCardinality returns 0 and only batchSize applies.
                 val gangCardinality = backend.getGangCardinality
                 val effectiveBatch =
                   if (gangCardinality > 0) math.min(batchSize, gangCardinality) else batchSize

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
@@ -115,7 +115,16 @@ private[spark] class ArmadaExecutorAllocator(
               // This prevents scale-up executors from landing on a different cluster.
               val isInitialBatch = currentCount == 0 && pending == 0
               if (isInitialBatch || backend.isReadyToAllocateMore) {
-                val toAllocate = math.min(gap, batchSize)
+                // Pre-capture, Armada enforces the gang cardinality across the bootstrap batch:
+                // submitting more than `gangCardinality` jobs causes every job past that point to
+                // be rejected with "cannot submit more jobs to gang than specified in gang
+                // cardinality", which the allocator's retry loop then resubmits indefinitely.
+                // Cap by gangCardinality so the per-tick submission never overflows the gang.
+                // Post-capture, getGangCardinality returns 0 and only batchSize applies.
+                val gangCardinality = backend.getGangCardinality
+                val effectiveBatch =
+                  if (gangCardinality > 0) math.min(batchSize, gangCardinality) else batchSize
+                val toAllocate = math.min(gap, effectiveBatch)
                 submitExecutorJobs(toAllocate, rpId)
               }
             }

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
@@ -115,10 +115,9 @@ private[spark] class ArmadaExecutorAllocator(
               // This prevents scale-up executors from landing on a different cluster.
               val isInitialBatch = currentCount == 0 && pending == 0
               if (isInitialBatch || backend.isReadyToAllocateMore) {
-                val gangCardinality = backend.getGangCardinality
-                val effectiveBatch =
-                  if (gangCardinality > 0) math.min(batchSize, gangCardinality) else batchSize
-                val toAllocate = math.min(gap, effectiveBatch)
+                // Cardinality is 0 after the initial batch since we do not use gang scheduling
+                // for scale-up executors, so this degrades to min(gap, batchSize) on later ticks.
+                val toAllocate = computeToAllocate(gap, backend.getGangCardinality)
                 submitExecutorJobs(toAllocate, rpId)
               }
             }
@@ -131,6 +130,25 @@ private[spark] class ArmadaExecutorAllocator(
       case NonFatal(e) =>
         logError(s"Error in allocation loop: ${e.getMessage}", e)
     }
+  }
+
+  /** Computes how many executor jobs to submit in a single allocation step.
+    *
+    * The batch is capped by the gang cardinality so that the initial gang submission in client mode
+    * does not over-submit beyond the gang's size. A non-positive cardinality means "no gang
+    * constraint", in which case the configured batch size is used as-is.
+    *
+    * @param gap
+    *   the number of executors still needed (target minus current+pending)
+    * @param gangCardinality
+    *   the gang cardinality, or <= 0 when no gang constraint applies
+    * @return
+    *   the number of jobs to submit, never exceeding the gap
+    */
+  private[armada] def computeToAllocate(gap: Int, gangCardinality: Int): Int = {
+    val effectiveBatch =
+      if (gangCardinality > 0) math.min(batchSize, gangCardinality) else batchSize
+    math.min(gap, effectiveBatch)
   }
 
   /** Submit executor jobs to Armada.

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.spark.scheduler.cluster.armada
+
+import io.armadaproject.armada.ArmadaClient
+
+import org.mockito.Mockito._
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.should.Matchers
+
+import org.apache.spark.SparkConf
+
+class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
+
+  /** Regression test for the gang-cardinality vs batchSize mismatch. Pre-capture, Armada enforces
+    * the gang cardinality across the bootstrap batch — submitting more than that causes every
+    * job past the cardinality to be rejected with "cannot submit more jobs to gang than
+    * specified in gang cardinality", which the allocator then retries indefinitely. The
+    * allocator must consult backend.getGangCardinality during each tick so the cap can be
+    * applied.
+    */
+  test("tryAllocateExecutors consults gangCardinality before submitting") {
+    val backend = mock(classOf[ArmadaClusterManagerBackend])
+    // Drive the loop into the submit branch: gap > 0 and isInitialBatch=true.
+    when(backend.getExecutorCounts).thenReturn((0, 0))
+    when(backend.isReadyToAllocateMore).thenReturn(true)
+    // Cardinality < batchSize would otherwise overflow the gang. Returning 1 exercises the cap.
+    when(backend.getGangCardinality).thenReturn(1)
+
+    val armadaClient = mock(classOf[ArmadaClient])
+    val conf = new SparkConf(false)
+      .set("spark.armada.allocation.batchSize", "4")
+
+    val allocator = new ArmadaExecutorAllocator(
+      armadaClient,
+      "test-queue",
+      "test-jobset",
+      conf,
+      "test-app",
+      backend
+    )
+
+    // Register a target so the allocator's loop body executes.
+    val rp = org.apache.spark.resource.ResourceProfile.getOrCreateDefaultProfile(conf)
+    allocator.setTotalExpectedExecutors(Map(rp -> 4))
+
+    val method = classOf[ArmadaExecutorAllocator].getDeclaredMethod("tryAllocateExecutors")
+    method.setAccessible(true)
+    method.invoke(allocator)
+
+    // The cap is read on every submission-eligible tick. Without the cap, the allocator would
+    // submit batchSize=4 jobs and overflow Armada's cardinality=1 gang.
+    verify(backend, atLeastOnce()).getGangCardinality
+  }
+}

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
@@ -22,22 +22,21 @@ import io.armadaproject.armada.ArmadaClient
 import org.mockito.Mockito._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
+import org.scalatest.prop.TableDrivenPropertyChecks
 
 import org.apache.spark.SparkConf
 
-class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
+class ArmadaExecutorAllocatorSuite
+    extends AnyFunSuite
+    with Matchers
+    with TableDrivenPropertyChecks {
 
-  test("tryAllocateExecutors consults gangCardinality before submitting") {
-    val backend = mock(classOf[ArmadaClusterManagerBackend])
-    when(backend.getExecutorCounts).thenReturn((0, 0))
-    when(backend.isReadyToAllocateMore).thenReturn(true)
-    when(backend.getGangCardinality).thenReturn(1)
-
+  private def newAllocator(batchSize: Int): ArmadaExecutorAllocator = {
+    val backend      = mock(classOf[ArmadaClusterManagerBackend])
     val armadaClient = mock(classOf[ArmadaClient])
     val conf = new SparkConf(false)
-      .set("spark.armada.allocation.batchSize", "4")
-
-    val allocator = new ArmadaExecutorAllocator(
+      .set("spark.armada.allocation.batchSize", batchSize.toString)
+    new ArmadaExecutorAllocator(
       armadaClient,
       "test-queue",
       "test-jobset",
@@ -45,14 +44,34 @@ class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
       "test-app",
       backend
     )
+  }
 
-    val rp = org.apache.spark.resource.ResourceProfile.getOrCreateDefaultProfile(conf)
-    allocator.setTotalExpectedExecutors(Map(rp -> 4))
+  test("computeToAllocate caps the batch by gang cardinality") {
+    val allocator = newAllocator(batchSize = 4)
 
-    val method = classOf[ArmadaExecutorAllocator].getDeclaredMethod("tryAllocateExecutors")
-    method.setAccessible(true)
-    method.invoke(allocator)
+    // (gap, gangCardinality, expectedToAllocate)
+    val cases = Table(
+      ("gap", "gangCardinality", "expected"),
+      // gang smaller than batch -> capped to the gang size (the bug this fix targets)
+      (4, 1, 1),
+      (4, 2, 2),
+      // gang larger than batch -> batch size wins
+      (4, 10, 4),
+      // gang equals batch -> batch size
+      (4, 4, 4),
+      // no gang constraint (<= 0) -> fall back to batch size
+      (4, 0, 4),
+      (4, -1, 4),
+      // gap smaller than the effective batch -> gap wins
+      (2, 4, 2),
+      (1, 10, 1),
+      (3, 5, 3),
+      // gap = 0 -> never submit, regardless of cardinality
+      (0, 5, 0)
+    )
 
-    verify(backend, atLeastOnce()).getGangCardinality
+    forAll(cases) { (gap: Int, gangCardinality: Int, expected: Int) =>
+      allocator.computeToAllocate(gap, gangCardinality) shouldBe expected
+    }
   }
 }

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
@@ -27,19 +27,10 @@ import org.apache.spark.SparkConf
 
 class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
 
-  /** Regression test for the gang-cardinality vs batchSize mismatch. Pre-capture, Armada enforces
-    * the gang cardinality across the bootstrap batch — submitting more than that causes every
-    * job past the cardinality to be rejected with "cannot submit more jobs to gang than
-    * specified in gang cardinality", which the allocator then retries indefinitely. The
-    * allocator must consult backend.getGangCardinality during each tick so the cap can be
-    * applied.
-    */
   test("tryAllocateExecutors consults gangCardinality before submitting") {
     val backend = mock(classOf[ArmadaClusterManagerBackend])
-    // Drive the loop into the submit branch: gap > 0 and isInitialBatch=true.
     when(backend.getExecutorCounts).thenReturn((0, 0))
     when(backend.isReadyToAllocateMore).thenReturn(true)
-    // Cardinality < batchSize would otherwise overflow the gang. Returning 1 exercises the cap.
     when(backend.getGangCardinality).thenReturn(1)
 
     val armadaClient = mock(classOf[ArmadaClient])
@@ -55,7 +46,6 @@ class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
       backend
     )
 
-    // Register a target so the allocator's loop body executes.
     val rp = org.apache.spark.resource.ResourceProfile.getOrCreateDefaultProfile(conf)
     allocator.setTotalExpectedExecutors(Map(rp -> 4))
 
@@ -63,8 +53,6 @@ class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
     method.setAccessible(true)
     method.invoke(allocator)
 
-    // The cap is read on every submission-eligible tick. Without the cap, the allocator would
-    // submit batchSize=4 jobs and overflow Armada's cardinality=1 gang.
     verify(backend, atLeastOnce()).getGangCardinality
   }
 }


### PR DESCRIPTION
**What:** Cap the initial gang executor batch by the gang cardinality so client-mode allocation never over-submits.

**Why:** In client mode the first allocation submits the whole gap up to `spark.armada.allocation.batchSize`, which can exceed the gang's cardinality and request more executors than the gang needs. Capping by cardinality keeps the initial gang submission correctly sized while leaving normal scale-up unchanged.

**Changes:**
- Add `getGangCardinality` on `ArmadaClusterManagerBackend`, delegating to the active deployment-mode helper.
- Extract batch math into `computeToAllocate(gap, gangCardinality)` in `ArmadaExecutorAllocator`, returning `min(gap, min(batchSize, gangCardinality))`.
- Treat a non-positive cardinality as "no gang constraint", falling back to the configured batch size.

**Tests:** Table-driven `ArmadaExecutorAllocatorSuite` asserts the computed allocation across gang-smaller, gang-larger, equal, no-constraint, and gap-limited cases.


Note: This work was originally suggested by @RammBagg 