### PR TITLE
Add option to run Maven in offline mode.

### DIFF
--- a/scripts/config.sh.example
+++ b/scripts/config.sh.example
@@ -34,3 +34,10 @@ ARMADA_QUEUE=test
 #ARMADA_AUTH_TOKEN=
 #ARMADA_AUTH_SCRIPT_PATH=/opt/spark/extraFiles/getAuthToken.sh
 #ARMADA_EVENT_WATCHER_USE_TLS=true
+
+# ── Maven Offline Mode ──────────────────────────────────────────────────────
+# Set this in config.sh to either "-o" or "--offline" to run Maven in offline
+# mode when your local Maven repository (e.g. $HOME/.m2/repository) is already
+# populated with dependency packages, to avoid build hangs due to origin repo
+# servers, such as Artifactory.
+export MVN_OFFLINE=""

--- a/scripts/config.sh.example
+++ b/scripts/config.sh.example
@@ -40,4 +40,4 @@ ARMADA_QUEUE=test
 # mode when your local Maven repository (e.g. $HOME/.m2/repository) is already
 # populated with dependency packages, to avoid build hangs due to origin repo
 # servers, such as Artifactory.
-export MVN_OFFLINE=""
+# export MVN_OFFLINE="-o"

--- a/scripts/createDssImage.sh
+++ b/scripts/createDssImage.sh
@@ -52,7 +52,7 @@ if [ -f "$spark_dockerfile" ]; then
     fi
 fi
 ./dev/change-scala-version.sh $SCALA_BIN_VERSION
-./build/mvn clean install --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION
+./build/mvn clean install ${MVN_OFFLINE-} --batch-mode -Dscalastyle.skip=true -DskipTests  -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION
 ./bin/docker-image-tool.sh -u 185 -t "$DSS_IMAGE_TAG"  -p ./resource-managers/kubernetes/docker/src/main/dockerfiles/spark/bindings/python/Dockerfile build
 cd ..
 

--- a/scripts/createImage.sh
+++ b/scripts/createImage.sh
@@ -66,9 +66,9 @@ elif [[ "$SPARK_VERSION" == "3."* ]] && ( [[ "$SCALA_BIN_VERSION" == "2.13" ]] |
             # spark-examples jars are not released, so we need to build these from sources.
             # The jars are platform agnostic, so a single Maven build serves every
             # target platform; only the docker image build below runs per arch.
-            ./build/mvn --batch-mode clean
-            ./build/mvn --batch-mode package -pl examples
-            ./build/mvn --batch-mode package -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION -pl assembly
+            ./build/mvn ${MVN_OFFLINE-} --batch-mode clean
+            ./build/mvn ${MVN_OFFLINE-} --batch-mode package -pl examples
+            ./build/mvn ${MVN_OFFLINE-} --batch-mode package -Pkubernetes -Phadoop-cloud -Pscala-$SCALA_BIN_VERSION -pl assembly
             for plat in "${missing_platforms[@]}"; do
                 arch="${plat##*/}"
                 echo "Building Spark Docker image $image_prefix:$image_tag-$arch for $plat from source."

--- a/scripts/dev-e2e.sh
+++ b/scripts/dev-e2e.sh
@@ -153,7 +153,7 @@ init-cluster() {
   echo "Checking if image $IMAGE_NAME is available"
   if ! docker image inspect "$IMAGE_NAME" > /dev/null 2>&1; then
     err "Image $IMAGE_NAME not found in local Docker instance."
-    err "Rebuild the image (cd '$scripts/..' && mvn test-compile && mvn clean package && ./scripts/createImage.sh -p), and re-run this script"
+    err "Rebuild the image (cd '$scripts/..' && mvn ${MVN_OFFLINE-} test-compile && mvn ${MVN_OFFLINE-} clean package && ./scripts/createImage.sh -p), and re-run this script"
     exit 1
   fi
 
@@ -246,7 +246,7 @@ run-test() {
 
   # Run the Scala E2E test suite
   env KUBERNETES_TRUST_CERTIFICATES=true \
-  mvn -e scalatest:test -Dsuites="org.apache.spark.deploy.armada.e2e.ArmadaSparkE2E" \
+  mvn ${MVN_OFFLINE-} -e scalatest:test -Dsuites="org.apache.spark.deploy.armada.e2e.ArmadaSparkE2E" \
     -Dcontainer.image="$IMAGE_NAME" \
     -Dscala.version="$SCALA_VERSION" \
     -Dscala.binary.version="$SCALA_BIN_VERSION" \

--- a/scripts/init.sh
+++ b/scripts/init.sh
@@ -285,12 +285,12 @@ fi
 
 # derive Scala and Spark versions from pom.xml, set via ./scripts/set-version.sh
 if [[ -z "${SCALA_VERSION:-}" ]]; then
-  export SCALA_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=scala.version -q -DforceStdout)
-  export SCALA_BIN_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=scala.binary.version -q -DforceStdout)
+  export SCALA_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=scala.version ${MVN_OFFLINE-} -q -DforceStdout)
+  export SCALA_BIN_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=scala.binary.version ${MVN_OFFLINE-} -q -DforceStdout)
 fi
 if [[ -z "${SPARK_VERSION:-}" ]]; then
-  export SPARK_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=spark.version -q -DforceStdout)
-  export SPARK_BIN_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=spark.binary.version -q -DforceStdout)
+  export SPARK_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=spark.version ${MVN_OFFLINE-} -q -DforceStdout)
+  export SPARK_BIN_VERSION=$(cd "$scripts/.."; mvn help:evaluate -Dexpression=spark.binary.version ${MVN_OFFLINE-} -q -DforceStdout)
 fi
 
 # When using DSS, validate Spark version + Scala version against known DSS base


### PR DESCRIPTION
Add an option to run Maven in offline mode, to avoid build hangs due to slow upstream servers. If running in offline mode and an artifact (e.g. a required `.jar`) is not in the local Maven repository (usually `$HOME/.m2/repository/...`), Maven will immediately render an error message showing the missing artifact and that it cannot fetch it in offline mode.