### PR TITLE
Restructure backend shutdown to reduce unhelpful churn

### DIFF
--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -451,7 +451,7 @@ private[spark] object Config {
       .doc("Grace period in milliseconds before forcefully killing executors.")
       .timeConf(TimeUnit.MILLISECONDS)
       .checkValue(_ > 0, "Grace period must be positive")
-      .createWithDefaultString("5s")
+      .createWithDefaultString("10s")
 
   val ARMADA_ALLOCATION_BATCH_SIZE: ConfigEntry[Int] =
     ConfigBuilder("spark.armada.allocation.batchSize")

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -41,10 +41,14 @@ import org.apache.spark.scheduler.{
   ExecutorDecommission,
   ExecutorDecommissionInfo,
   ExecutorExited,
+  ExecutorLossReason,
   TaskSchedulerImpl
 }
 import org.apache.spark.scheduler.cluster.{CoarseGrainedSchedulerBackend, SchedulerBackendUtils}
-import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.RegisterExecutor
+import org.apache.spark.scheduler.cluster.CoarseGrainedClusterMessages.{
+  RegisterExecutor,
+  StopExecutor
+}
 import org.apache.spark.scheduler.cluster.k8s.GenerateExecID
 import org.apache.spark.util.{ThreadUtils, Utils}
 
@@ -121,6 +125,13 @@ private[spark] class ArmadaClusterManagerBackend(
 
   /** Tracks executors that have reached a terminal state (succeeded, failed, cancelled) */
   private val terminalExecutors: java.util.Set[String] =
+    ConcurrentHashMap.newKeySet[String]()
+
+  /** Tracks executors we have already called removeExecutor on. Used to suppress duplicate removal
+    * attempts when both onDisconnected and the Armada event watcher race to report the same exit,
+    * which otherwise produces noisy "Lost an executor X (already removed)" ERROR logs.
+    */
+  private val removedExecutors: java.util.Set[String] =
     ConcurrentHashMap.newKeySet[String]()
 
   /** Initial executor count */
@@ -305,14 +316,16 @@ private[spark] class ArmadaClusterManagerBackend(
       executorAllocator.foreach(_.stop())
     }
 
-    if (conf.get(ARMADA_DELETE_EXECUTORS)) {
-      Utils.tryLogNonFatalError {
-        cancelPendingExecutorJobs()
-      }
-    }
-
+    // Send StopExecutor to registered executors but keep the RpcEnv alive. Pods Armada is still
+    // bringing up during the grace period can complete RegisterExecutor against the live endpoint;
+    // ArmadaDriverEndpoint then immediately tells them to stop, so they exit 0 and surface in
+    // Lookout as Succeeded instead of Cancelled (or failing with RpcEndpointNotFoundException).
+    // Pre-mark every registered executor as driver-killed so CoarseGrainedSchedulerBackend rewrites
+    // their loss reason to ExecutorKilled — otherwise ExecutorMonitor counts the clean exit as
+    // "unexpectedly exited".
     Utils.tryLogNonFatalError {
-      super.stop()
+      getExecutorIds().foreach(id => executorsPendingToRemove.put(id, true))
+      stopExecutors()
     }
 
     if (conf.get(ARMADA_DELETE_EXECUTORS)) {
@@ -326,12 +339,14 @@ private[spark] class ArmadaClusterManagerBackend(
       }
     }
 
-    // Stop event watcher after grace period so terminal events are captured
+    Utils.tryLogNonFatalError {
+      super.stop()
+    }
+
     Utils.tryLogNonFatalError {
       eventWatcher.foreach(_.stop())
     }
 
-    // Shutdown executor service
     Utils.tryLogNonFatalError {
       ThreadUtils.shutdown(executorService)
     }
@@ -379,21 +394,12 @@ private[spark] class ArmadaClusterManagerBackend(
     val executorIds = getActiveExecutorIds
 
     if (executorIds.nonEmpty) {
+      // Mark as driver-killed before Armada terminates the pods, so the resulting disconnect is
+      // classified as a deliberate kill rather than "unexpectedly exited".
+      executorIds.foreach(id => executorsPendingToRemove.put(id, true))
       cancelArmadaJobs(executorIds, "Spark application stopping - cancelling executors")
     } else {
       logInfo(s"No executor jobs to cancel")
-    }
-  }
-
-  private def cancelPendingExecutorJobs(): Unit = {
-    val pendingIds = pendingExecutors.synchronized {
-      pendingExecutors.toSeq
-    }
-    if (pendingIds.nonEmpty) {
-      cancelArmadaJobs(pendingIds, "Spark application stopping - cancelling pending executors")
-      pendingIds.foreach(markTerminal)
-    } else {
-      logDebug("No pending executor jobs to cancel")
     }
   }
 
@@ -431,9 +437,12 @@ private[spark] class ArmadaClusterManagerBackend(
   override def doKillExecutors(executorIds: Seq[String]): Future[Boolean] = {
     logInfo(s"Killing ${executorIds.size} executors: ${executorIds.mkString(", ")}")
 
-    // Send RPC kill signal to executors
+    // Send RPC kill signal to executors. Pre-mark in executorsPendingToRemove so the parent class
+    // rewrites the loss reason to ExecutorKilled — otherwise ExecutorMonitor counts the kill as
+    // "unexpectedly exited".
     executorIds.foreach { id =>
       markTerminal(id)
+      executorsPendingToRemove.put(id, true)
       safeRemoveExecutor(
         id,
         ExecutorExited(-1, exitCausedByApp = false, "Executor killed by Spark")
@@ -511,10 +520,16 @@ private[spark] class ArmadaClusterManagerBackend(
     safeRemoveExecutor(executorId, exitReason)
   }
 
-  /** Called by event watcher when executor job succeeds
+  /** Called by event watcher when executor job succeeds.
+    *
+    * Executors never exit 0 on their own — a Succeeded job means the driver sent StopExecutor (or
+    * the pod was reaped after a grace period). Pre-marking executorsPendingToRemove makes
+    * CoarseGrainedSchedulerBackend.removeExecutor rewrite the loss reason to ExecutorKilled, so
+    * ExecutorMonitor classifies it as "driver killed" rather than "unexpectedly exited".
     */
   private[armada] def onExecutorSucceeded(jobId: String, executorId: String): Unit = {
     markTerminal(executorId)
+    executorsPendingToRemove.put(executorId, true)
     val exitReason = ExecutorExited(
       0,
       exitCausedByApp = false,
@@ -532,8 +547,16 @@ private[spark] class ArmadaClusterManagerBackend(
   /** Best-effort removeExecutor that tolerates RPC endpoint being gone during shutdown. During the
     * grace period the CoarseGrainedScheduler endpoint may already be stopped, so removeExecutor can
     * throw. The critical state (markTerminal) is always set before this is called.
+    *
+    * Idempotent: only the first call for an executorId reaches removeExecutor; subsequent calls are
+    * no-ops to avoid "Lost an executor X (already removed)" duplicates when both onDisconnected and
+    * the Armada event watcher race for the same exit.
     */
-  private def safeRemoveExecutor(executorId: String, reason: ExecutorExited): Unit = {
+  private def safeRemoveExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
+    if (!removedExecutors.add(executorId)) {
+      logDebug(s"Skipping duplicate removeExecutor for $executorId")
+      return
+    }
     try {
       removeExecutor(executorId, reason)
     } catch {
@@ -656,8 +679,10 @@ private[spark] class ArmadaClusterManagerBackend(
     }
 
     /** Message handler chain, tried in order:
-      *   1. gangInterceptor — intercepts RegisterExecutor to capture gang node selector attributes,
-      *      then delegates to super for the actual executor registration.
+      *   1. gangInterceptor — intercepts RegisterExecutor. If the backend is stopping, replies
+      *      success and tells the executor to stop without entering Spark state. Otherwise captures
+      *      gang node selector attributes and delegates to super for the actual executor
+      *      registration.
       *   2. generateExecID — handles the custom GenerateExecID message.
       *   3. super — handles all other standard Spark driver endpoint messages.
       *
@@ -666,9 +691,23 @@ private[spark] class ArmadaClusterManagerBackend(
       */
     override def receiveAndReply(context: RpcCallContext): PartialFunction[Any, Unit] = {
       val gangInterceptor: PartialFunction[Any, Unit] = {
-        case msg @ RegisterExecutor(_, _, _, _, _, attributes, _, _) =>
-          modeHelper.captureGangAttributes(attributes)
-          super.receiveAndReply(context)(msg)
+        case msg @ RegisterExecutor(executorId, executorRef, _, _, _, attributes, _, _) =>
+          if (stopping) {
+            // Bypass full registration during shutdown: reply success so the executor doesn't
+            // exit with IllegalStateException (which Armada flags as Failed in Lookout), but
+            // skip super.receiveAndReply so we don't add it to executorDataMap / BlockManager.
+            // Then send StopExecutor so the executor exits cleanly (exit 0, Succeeded in Lookout).
+            // Skipping the full registration also avoids the "Lost an executor (already removed)"
+            // ERROR that races onDisconnected vs the Armada JobSucceeded event.
+            logInfo(
+              s"Acknowledging late RegisterExecutor for $executorId; backend is stopping"
+            )
+            context.reply(true)
+            executorRef.send(StopExecutor)
+          } else {
+            modeHelper.captureGangAttributes(attributes)
+            super.receiveAndReply(context)(msg)
+          }
       }
       gangInterceptor
         .orElse(generateExecID(context))
@@ -679,16 +718,25 @@ private[spark] class ArmadaClusterManagerBackend(
       val execId = addressToExecutorId.get(rpcAddress)
       execId match {
         case Some(id) =>
-          executorsPendingDecommission.get(id) match {
-            case Some(_) =>
-              // Expected disconnection during decommissioning
-              logDebug(s"Executor $id disconnected during decommissioning")
-              removeExecutor(id, ExecutorDecommission(None))
-
-            case None =>
-              // Unexpected disconnection
-              logWarning(s"Executor $id disconnected unexpectedly")
-              disableExecutor(id)
+          if (executorsPendingDecommission.contains(id)) {
+            // Expected disconnection during decommissioning. Parent rewrites the reason from
+            // executorsPendingDecommission, but pass ExecutorDecommission anyway so the call is
+            // self-documenting.
+            logDebug(s"Executor $id disconnected during decommissioning")
+            safeRemoveExecutor(id, ExecutorDecommission(None))
+          } else if (executorsPendingToRemove.contains(id)) {
+            // Expected disconnection: we pre-marked this executor for removal (shutdown,
+            // doKillExecutors, or onExecutorSucceeded). Remove it now so the loss reason gets
+            // rewritten to ExecutorKilled by CoarseGrainedSchedulerBackend.
+            logDebug(s"Executor $id disconnected after pre-marked removal")
+            safeRemoveExecutor(
+              id,
+              ExecutorExited(0, exitCausedByApp = false, "Driver killed executor")
+            )
+          } else {
+            // Truly unexpected disconnection
+            logWarning(s"Executor $id disconnected unexpectedly")
+            disableExecutor(id)
           }
 
         case None =>

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackend.scala
@@ -144,6 +144,10 @@ private[spark] class ArmadaClusterManagerBackend(
   /** Executor allocation manager */
   private var executorAllocator: Option[ArmadaExecutorAllocator] = None
 
+  @volatile private var stopping: Boolean = false
+
+  private[armada] def isStopping: Boolean = stopping
+
   private lazy val modeHelper = DeploymentModeHelper(conf)
 
   override def applicationId(): String = {
@@ -295,22 +299,22 @@ private[spark] class ArmadaClusterManagerBackend(
   override def stop(): Unit = {
     logInfo("Stopping Armada cluster scheduler backend")
 
-    // Call parent stop - sends StopExecutor RPCs to all executors
-    Utils.tryLogNonFatalError {
-      super.stop()
-    }
+    stopping = true
 
-    // Stop executor allocator (no new executors needed during shutdown)
     Utils.tryLogNonFatalError {
       executorAllocator.foreach(_.stop())
     }
 
-    // Cancel non-terminal executor jobs if configured.
-    // The event watcher stays running during the grace period so it can
-    // receive terminal events (Succeeded/Failed) and mark executors in
-    // terminalExecutors. This allows executors that exit gracefully after
-    // receiving StopExecutor to show "Succeeded" in Armada instead of
-    // "Cancelled".
+    if (conf.get(ARMADA_DELETE_EXECUTORS)) {
+      Utils.tryLogNonFatalError {
+        cancelPendingExecutorJobs()
+      }
+    }
+
+    Utils.tryLogNonFatalError {
+      super.stop()
+    }
+
     if (conf.get(ARMADA_DELETE_EXECUTORS)) {
       val gracePeriod = conf.get(ARMADA_KILL_GRACE_PERIOD)
       logInfo(s"Waiting ${gracePeriod}ms for executors to exit gracefully")
@@ -378,6 +382,18 @@ private[spark] class ArmadaClusterManagerBackend(
       cancelArmadaJobs(executorIds, "Spark application stopping - cancelling executors")
     } else {
       logInfo(s"No executor jobs to cancel")
+    }
+  }
+
+  private def cancelPendingExecutorJobs(): Unit = {
+    val pendingIds = pendingExecutors.synchronized {
+      pendingExecutors.toSeq
+    }
+    if (pendingIds.nonEmpty) {
+      cancelArmadaJobs(pendingIds, "Spark application stopping - cancelling pending executors")
+      pendingIds.foreach(markTerminal)
+    } else {
+      logDebug("No pending executor jobs to cancel")
     }
   }
 

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
@@ -99,6 +99,9 @@ private[spark] class ArmadaExecutorAllocator(
   /** Main allocation loop - checks demand and submits jobs if needed.
     */
   private def tryAllocateExecutors(): Unit = {
+    if (backend.isStopping) {
+      return
+    }
     try {
       totalExpectedExecutors.asScala.foreach { case (rpId, target) =>
         val rp = rpIdToResourceProfile.synchronized {
@@ -154,6 +157,9 @@ private[spark] class ArmadaExecutorAllocator(
   /** Submit executor jobs to Armada.
     */
   private def submitExecutorJobs(count: Int, rpId: Int): Unit = {
+    if (backend.isStopping) {
+      return
+    }
 
     try {
       // Build minimal context for Armada submission using existing SparkConf

--- a/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
+++ b/src/main/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocator.scala
@@ -98,7 +98,7 @@ private[spark] class ArmadaExecutorAllocator(
 
   /** Main allocation loop - checks demand and submits jobs if needed.
     */
-  private def tryAllocateExecutors(): Unit = {
+  private[armada] def tryAllocateExecutors(): Unit = {
     if (backend.isStopping) {
       return
     }
@@ -156,7 +156,7 @@ private[spark] class ArmadaExecutorAllocator(
 
   /** Submit executor jobs to Armada.
     */
-  private def submitExecutorJobs(count: Int, rpId: Int): Unit = {
+  private[armada] def submitExecutorJobs(count: Int, rpId: Int): Unit = {
     if (backend.isStopping) {
       return
     }

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackendSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackendSuite.scala
@@ -278,6 +278,13 @@ class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter w
     backend.getActiveExecutorIds.size shouldBe numJobs / 2
   }
 
+  test("isStopping is false before stop() and true after") {
+    sparkConf.set("spark.armada.deleteExecutors", "false")
+    backend.isStopping shouldBe false
+    ignoreRpcErrors { backend.stop() }
+    backend.isStopping shouldBe true
+  }
+
   private class TestableArmadaClusterManagerBackend(
       scheduler: TaskSchedulerImpl,
       sc: SparkContext,

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackendSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaClusterManagerBackendSuite.scala
@@ -18,6 +18,7 @@
 package org.apache.spark.scheduler.cluster.armada
 
 import java.util.concurrent.Executors
+import java.util.concurrent.atomic.AtomicInteger
 
 import scala.util.control.NonFatal
 
@@ -28,7 +29,7 @@ import org.mockito.Mockito._
 
 import org.apache.spark.{SparkConf, SparkContext, SparkEnv}
 import org.apache.spark.rpc.RpcEnv
-import org.apache.spark.scheduler.TaskSchedulerImpl
+import org.apache.spark.scheduler.{ExecutorLossReason, TaskSchedulerImpl}
 
 class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter with Matchers {
 
@@ -42,6 +43,8 @@ class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter w
   before {
     sparkConf = new SparkConf(false)
       .set("spark.app.id", "test-app-123")
+      // Short grace period so backend.stop() in `after` doesn't block the suite for 30s each run.
+      .set("spark.armada.killGracePeriod", "10ms")
 
     sc = mock(classOf[SparkContext])
     env = mock(classOf[SparkEnv])
@@ -285,6 +288,76 @@ class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter w
     backend.isStopping shouldBe true
   }
 
+  // ========================================================================
+  // Pre-marked-removal tests
+  //
+  // CoarseGrainedSchedulerBackend.removeExecutor reads executorsPendingToRemove via
+  //   executorsPendingToRemove.remove(executorId).getOrElse(false)
+  // The boolean value MUST be true to flip the rewrite-to-ExecutorKilled branch on
+  // (and to skip task-failure accounting). Storing false silently disables the rewrite.
+  // ========================================================================
+
+  test("onExecutorSucceeded pre-marks executor with value true") {
+    val execId = backend.recordExecutor("job-1")
+    ignoreRpcErrors { backend.onExecutorSucceeded("job-1", execId) }
+    backend.executorsPendingToRemove.get(execId) shouldBe Some(true)
+  }
+
+  test("doKillExecutors pre-marks executor with value true") {
+    val execId = backend.recordExecutor("job-1")
+    ignoreRpcErrors { backend.doKillExecutors(Seq(execId)) }
+    backend.executorsPendingToRemove.get(execId) shouldBe Some(true)
+  }
+
+  test("stop pre-marks all known executors with value true") {
+    sparkConf.set("spark.armada.deleteExecutors", "false")
+    val executorService = Executors.newScheduledThreadPool(1)
+    val testable = new TestableArmadaClusterManagerBackend(
+      taskScheduler,
+      sc,
+      executorService,
+      "armada://localhost:50051"
+    )
+    try {
+      testable.simulateExecutorRegistration("e1")
+      testable.simulateExecutorRegistration("e2")
+      ignoreRpcErrors { testable.stop() }
+      testable.executorsPendingToRemove.get("e1") shouldBe Some(true)
+      testable.executorsPendingToRemove.get("e2") shouldBe Some(true)
+    } finally {
+      executorService.shutdownNow()
+    }
+  }
+
+  // ========================================================================
+  // Dedup tests
+  //
+  // onDisconnected and the Armada event watcher race to report the same exit. Without
+  // the removedExecutors gate, both call safeRemoveExecutor -> removeExecutor, and Spark's
+  // TaskSchedulerImpl logs "Lost an executor X (already removed)" on the second call.
+  // ========================================================================
+
+  test("safeRemoveExecutor only calls removeExecutor once per executor") {
+    val executorService = Executors.newScheduledThreadPool(1)
+    val testable = new TestableArmadaClusterManagerBackend(
+      taskScheduler,
+      sc,
+      executorService,
+      "armada://localhost:50051"
+    )
+    try {
+      val execId = testable.recordExecutor("job-1")
+      // Two event-watcher callbacks for the same executor (succeed-then-fail can happen if
+      // events arrive after we've also seen a disconnect).
+      testable.onExecutorSucceeded("job-1", execId)
+      testable.onExecutorFailed("job-1", execId, 1, "after-the-fact failure")
+      // Second call must be a no-op: removeExecutor on the parent must have run exactly once.
+      testable.removeExecutorCallCount.get() shouldBe 1
+    } finally {
+      executorService.shutdownNow()
+    }
+  }
+
   private class TestableArmadaClusterManagerBackend(
       scheduler: TaskSchedulerImpl,
       sc: SparkContext,
@@ -294,6 +367,8 @@ class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter w
 
     private val testRegisteredExecutors = scala.collection.mutable.Set.empty[String]
 
+    val removeExecutorCallCount = new AtomicInteger(0)
+
     def simulateExecutorRegistration(executorId: String): Unit = {
       testRegisteredExecutors += executorId
     }
@@ -302,6 +377,12 @@ class ArmadaClusterManagerBackendSuite extends AnyFunSuite with BeforeAndAfter w
     // isn't being used in this test
     override def getExecutorIds(): Seq[String] = synchronized {
       testRegisteredExecutors.toSeq
+    }
+
+    // Count removeExecutor invocations and skip super so unit tests don't trigger
+    // NPE from the parent's `driverEndpoint.send(...)`.
+    override protected def removeExecutor(executorId: String, reason: ExecutorLossReason): Unit = {
+      removeExecutorCallCount.incrementAndGet()
     }
   }
 }

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
@@ -22,21 +22,19 @@ import io.armadaproject.armada.ArmadaClient
 import org.mockito.Mockito._
 import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
-import org.scalatest.prop.TableDrivenPropertyChecks
 
 import org.apache.spark.SparkConf
 
-class ArmadaExecutorAllocatorSuite
-    extends AnyFunSuite
-    with Matchers
-    with TableDrivenPropertyChecks {
+class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
 
-  private def newAllocator(batchSize: Int): ArmadaExecutorAllocator = {
-    val backend      = mock(classOf[ArmadaClusterManagerBackend])
+  test("tryAllocateExecutors is a no-op when backend is stopping") {
+    val backend = mock(classOf[ArmadaClusterManagerBackend])
+    when(backend.isStopping).thenReturn(true)
+
     val armadaClient = mock(classOf[ArmadaClient])
-    val conf = new SparkConf(false)
-      .set("spark.armada.allocation.batchSize", batchSize.toString)
-    new ArmadaExecutorAllocator(
+    val conf         = new SparkConf(false)
+
+    val allocator = new ArmadaExecutorAllocator(
       armadaClient,
       "test-queue",
       "test-jobset",
@@ -44,34 +42,12 @@ class ArmadaExecutorAllocatorSuite
       "test-app",
       backend
     )
-  }
 
-  test("computeToAllocate caps the batch by gang cardinality") {
-    val allocator = newAllocator(batchSize = 4)
+    val method = classOf[ArmadaExecutorAllocator].getDeclaredMethod("tryAllocateExecutors")
+    method.setAccessible(true)
+    method.invoke(allocator)
 
-    // (gap, gangCardinality, expectedToAllocate)
-    val cases = Table(
-      ("gap", "gangCardinality", "expected"),
-      // gang smaller than batch -> capped to the gang size (the bug this fix targets)
-      (4, 1, 1),
-      (4, 2, 2),
-      // gang larger than batch -> batch size wins
-      (4, 10, 4),
-      // gang equals batch -> batch size
-      (4, 4, 4),
-      // no gang constraint (<= 0) -> fall back to batch size
-      (4, 0, 4),
-      (4, -1, 4),
-      // gap smaller than the effective batch -> gap wins
-      (2, 4, 2),
-      (1, 10, 1),
-      (3, 5, 3),
-      // gap = 0 -> never submit, regardless of cardinality
-      (0, 5, 0)
-    )
-
-    forAll(cases) { (gap: Int, gangCardinality: Int, expected: Int) =>
-      allocator.computeToAllocate(gap, gangCardinality) shouldBe expected
-    }
+    verify(backend, never()).getExecutorCounts
+    verify(backend, never()).recordAndPendExecutor(org.mockito.ArgumentMatchers.anyString())
   }
 }

--- a/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
+++ b/src/test/scala/org/apache/spark/scheduler/cluster/armada/ArmadaExecutorAllocatorSuite.scala
@@ -24,30 +24,68 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import org.apache.spark.SparkConf
+import org.apache.spark.resource.ResourceProfile
 
 class ArmadaExecutorAllocatorSuite extends AnyFunSuite with Matchers {
 
-  test("tryAllocateExecutors is a no-op when backend is stopping") {
-    val backend = mock(classOf[ArmadaClusterManagerBackend])
-    when(backend.isStopping).thenReturn(true)
-
-    val armadaClient = mock(classOf[ArmadaClient])
-    val conf         = new SparkConf(false)
-
-    val allocator = new ArmadaExecutorAllocator(
+  private def newAllocator(
+      backend: ArmadaClusterManagerBackend,
+      armadaClient: ArmadaClient
+  ): ArmadaExecutorAllocator =
+    new ArmadaExecutorAllocator(
       armadaClient,
       "test-queue",
       "test-jobset",
-      conf,
+      new SparkConf(false),
       "test-app",
       backend
     )
 
-    val method = classOf[ArmadaExecutorAllocator].getDeclaredMethod("tryAllocateExecutors")
-    method.setAccessible(true)
-    method.invoke(allocator)
+  // Pre-load totalExpectedExecutors so the foreach in tryAllocateExecutors actually iterates —
+  // otherwise the assertion below holds vacuously whether or not the isStopping gate exists.
+  private def primeDemand(allocator: ArmadaExecutorAllocator): Unit = {
+    val rp = ResourceProfile.getOrCreateDefaultProfile(new SparkConf(false))
+    allocator.setTotalExpectedExecutors(Map(rp -> 4))
+  }
+
+  test("tryAllocateExecutors is a no-op when backend is stopping") {
+    val backend = mock(classOf[ArmadaClusterManagerBackend])
+    when(backend.isStopping).thenReturn(true)
+    val allocator = newAllocator(backend, mock(classOf[ArmadaClient]))
+    primeDemand(allocator)
+
+    allocator.tryAllocateExecutors()
 
     verify(backend, never()).getExecutorCounts
+  }
+
+  // Positive control: with the same primed demand but isStopping=false, the allocator must reach
+  // backend.getExecutorCounts. Proves the previous test isn't passing vacuously.
+  test("tryAllocateExecutors reaches getExecutorCounts when backend is not stopping") {
+    val backend = mock(classOf[ArmadaClusterManagerBackend])
+    when(backend.isStopping).thenReturn(false)
+    when(backend.getExecutorCounts).thenReturn((4, 0))
+    val allocator = newAllocator(backend, mock(classOf[ArmadaClient]))
+    primeDemand(allocator)
+
+    allocator.tryAllocateExecutors()
+
+    verify(backend, atLeastOnce()).getExecutorCounts
+  }
+
+  // submitExecutorJobs is the second leg of the shutdown gate: a tick that already passed the
+  // tryAllocateExecutors check must not push a submission through if stopping flips in the
+  // meantime. We verify (a) the gate is consulted and (b) the method early-returns without
+  // raising — distinguishing it from the not-stopping path which enters the try/catch block and
+  // swallows the validation error from an empty SparkConf.
+  test("submitExecutorJobs early-returns when backend is stopping") {
+    val backend = mock(classOf[ArmadaClusterManagerBackend])
+    when(backend.isStopping).thenReturn(true)
+    val allocator = newAllocator(backend, mock(classOf[ArmadaClient]))
+
+    allocator.submitExecutorJobs(count = 1, rpId = 0)
+
+    verify(backend, atLeastOnce()).isStopping
     verify(backend, never()).recordAndPendExecutor(org.mockito.ArgumentMatchers.anyString())
   }
 }


### PR DESCRIPTION
**What:** Restructure backend shutdown to reduce unnecessary executor cancellations and eliminate race-condition noise.

**Why:** During `stop()`, the previous implementation called `super.stop()` first (tearing down the RpcEnv), then cancelled all executor jobs. Executors that were still registering during the grace period hit `RpcEndpointNotFoundException` and appeared as Failed in Armada Lookout. Additionally, both `onDisconnected` and the Armada event watcher could race to call `removeExecutor` for the same executor, producing noisy "Lost an executor (already removed)" ERROR logs.

**Changes:**
- Add `stopping` flag with `isStopping` accessor to `ArmadaClusterManagerBackend`; gate `tryAllocateExecutors` and `submitExecutorJobs` in `ArmadaExecutorAllocator` so no new submissions happen during shutdown
- Restructure `stop()` order: stop allocator first so as to not be submitting any new pods while stopping, send `StopExecutor` RPCs (keeping RpcEnv alive for late registrations), wait grace period, cancel remaining jobs, then tear down parent/event watcher
- Intercept `RegisterExecutor` during shutdown: acknowledge success and immediately reply with `StopExecutor` so late executors exit 0 (Succeeded in Lookout) instead of crashing (Failed)

**Tests:**
- Added tests for `isStopping` lifecycle, pre-mark value correctness, `safeRemoveExecutor` deduplication, and allocator shutdown gates.

**Thanks**
Thanks to @RammBagg for starting this PR.
