### PR TITLE
add armada to sparksubmit resource flag masks

### DIFF
--- a/src/main/scala-spark-3.3/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-3.3/org/apache/spark/deploy/SparkSubmit.scala
@@ -725,13 +725,13 @@ private[spark] class SparkSubmit extends Logging {
       ),
       OptionAssigner(
         args.executorCores,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key
       ),
       OptionAssigner(
         args.executorMemory,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_MEMORY.key
       ),
@@ -762,13 +762,13 @@ private[spark] class SparkSubmit extends Logging {
       ),
       OptionAssigner(
         args.driverMemory,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_MEMORY.key
       ),
       OptionAssigner(
         args.driverCores,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_CORES.key
       ),

--- a/src/main/scala-spark-3.5/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-3.5/org/apache/spark/deploy/SparkSubmit.scala
@@ -766,13 +766,13 @@ private[spark] class SparkSubmit extends Logging {
       ),
       OptionAssigner(
         args.executorCores,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key
       ),
       OptionAssigner(
         args.executorMemory,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_MEMORY.key
       ),
@@ -803,13 +803,13 @@ private[spark] class SparkSubmit extends Logging {
       ),
       OptionAssigner(
         args.driverMemory,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_MEMORY.key
       ),
       OptionAssigner(
         args.driverCores,
-        STANDALONE | MESOS | YARN | KUBERNETES,
+        STANDALONE | MESOS | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_CORES.key
       ),

--- a/src/main/scala-spark-4.1/org/apache/spark/deploy/SparkSubmit.scala
+++ b/src/main/scala-spark-4.1/org/apache/spark/deploy/SparkSubmit.scala
@@ -773,13 +773,13 @@ private[spark] class SparkSubmit extends Logging {
       ),
       OptionAssigner(
         args.executorCores,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_CORES.key
       ),
       OptionAssigner(
         args.executorMemory,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         ALL_DEPLOY_MODES,
         confKey = EXECUTOR_MEMORY.key
       ),
@@ -805,13 +805,13 @@ private[spark] class SparkSubmit extends Logging {
       OptionAssigner(args.jars, STANDALONE | KUBERNETES | ARMADA, ALL_DEPLOY_MODES, confKey = JARS.key),
       OptionAssigner(
         args.driverMemory,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_MEMORY.key
       ),
       OptionAssigner(
         args.driverCores,
-        STANDALONE | YARN | KUBERNETES,
+        STANDALONE | YARN | KUBERNETES | ARMADA,
         CLUSTER,
         confKey = DRIVER_CORES.key
       ),

--- a/src/main/scala/org/apache/spark/deploy/armada/Config.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/Config.scala
@@ -397,6 +397,12 @@ private[spark] object Config {
 
   val DEFAULT_MEM                   = "1Gi"
   val DEFAULT_SPARK_EXECUTOR_MEMORY = "1g"
+
+  // Floor for derived non-heap memory overhead, matching Spark's own default. Defined here rather
+  // than reused from Spark because it moved between releases: 3.3 and 3.5 expose it as
+  // ResourceProfile.MEMORY_OVERHEAD_MIN_MIB, while 4.1 replaced it with the
+  // spark.{driver,executor}.minMemoryOverhead config entries.
+  val MIN_MEMORY_OVERHEAD_MIB = 384L
   val ARMADA_DRIVER_LIMIT_MEMORY: OptionalConfigEntry[String] =
     ConfigBuilder("spark.armada.driver.limit.memory")
       .doc("Specify the hard memory limit for the driver pod")

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -62,6 +62,7 @@ import org.apache.spark.deploy.armada.Config.{
   DEFAULT_MEM,
   DEFAULT_SPARK_EXECUTOR_CORES,
   DEFAULT_SPARK_EXECUTOR_MEMORY,
+  MIN_MEMORY_OVERHEAD_MIB,
   commaSeparatedAnnotationsToMap,
   commaSeparatedLabelsToMap
 }
@@ -88,9 +89,22 @@ import org.apache.spark.deploy.k8s.Config.{
 import org.apache.hadoop.fs.FileSystem
 import org.apache.spark.{SecurityManager, SparkConf}
 import org.apache.spark.deploy.SparkHadoopUtil
-import org.apache.spark.internal.config.{DRIVER_PORT, DRIVER_HOST_ADDRESS, DYN_ALLOCATION_ENABLED}
+import org.apache.spark.internal.config.{
+  ConfigEntry,
+  DRIVER_HOST_ADDRESS,
+  DRIVER_MEMORY,
+  DRIVER_MEMORY_OVERHEAD,
+  DRIVER_MEMORY_OVERHEAD_FACTOR,
+  DRIVER_PORT,
+  DYN_ALLOCATION_ENABLED,
+  EXECUTOR_MEMORY,
+  EXECUTOR_MEMORY_OVERHEAD,
+  EXECUTOR_MEMORY_OVERHEAD_FACTOR,
+  OptionalConfigEntry
+}
 import org.apache.spark.resource.ResourceProfile
 import org.apache.spark.scheduler.cluster.k8s.KubernetesExecutorBuilder
+import org.apache.spark.util.Utils
 import io.fabric8.kubernetes.client.DefaultKubernetesClient
 
 import scala.util.control.NonFatal
@@ -1563,11 +1577,20 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
 
     val templateResources = extractResourcesFromTemplate(armadaJobConfig.driverJobItemTemplate)
 
+    val derivedMemory = derivePodMemory(
+      conf,
+      DRIVER_MEMORY,
+      DRIVER_MEMORY_OVERHEAD,
+      DRIVER_MEMORY_OVERHEAD_FACTOR,
+      includeOffHeap = false
+    ).map(value => Quantity(Option(value)))
+
     val driverLimits = Map(
       "memory" -> {
         armadaJobConfig.cliConfig.driverResources.limitMemory
           .map(value => Quantity(Option(value)))
           .orElse(templateResources.flatMap(_.limits.get("memory")))
+          .orElse(derivedMemory)
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1583,6 +1606,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
         armadaJobConfig.cliConfig.driverResources.requestMemory
           .map(value => Quantity(Option(value)))
           .orElse(templateResources.flatMap(_.requests.get("memory")))
+          .orElse(derivedMemory)
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1688,11 +1712,20 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
 
     val templateResources = extractResourcesFromTemplate(armadaJobConfig.executorJobItemTemplate)
 
+    val derivedMemory = derivePodMemory(
+      conf,
+      EXECUTOR_MEMORY,
+      EXECUTOR_MEMORY_OVERHEAD,
+      EXECUTOR_MEMORY_OVERHEAD_FACTOR,
+      includeOffHeap = true
+    ).map(value => Quantity(Option(value)))
+
     val executorLimits = Map(
       "memory" -> {
         armadaJobConfig.cliConfig.executorResources.limitMemory
           .map(value => Quantity(Option(value)))
           .orElse(templateResources.flatMap(_.limits.get("memory")))
+          .orElse(derivedMemory)
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1708,6 +1741,7 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
         armadaJobConfig.cliConfig.executorResources.requestMemory
           .map(value => Quantity(Option(value)))
           .orElse(templateResources.flatMap(_.requests.get("memory")))
+          .orElse(derivedMemory)
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1936,6 +1970,51 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       container <- podSpec.containers.headOption
       res       <- container.resources
     } yield res
+  }
+
+  /** Derives the pod memory a Spark process needs from its JVM heap size.
+    *
+    * Mirrors how Spark sizes pods on Kubernetes, where no separate pod memory setting is exposed
+    * and the container is always heap plus non-heap overhead. Without this, a job that raises
+    * `spark.executor.memory` alone keeps the default pod size and is OOMKilled. The heap, overhead
+    * and overhead fraction all come from Spark's own config entries, which are stable across the
+    * Spark versions we build against.
+    *
+    * Returns None when the heap size is not configured, leaving existing behaviour untouched for
+    * jobs that never asked for a particular size.
+    *
+    * @param conf
+    *   Spark configuration to read the heap and overhead settings from
+    * @param memoryConf
+    *   Heap config entry, e.g. `EXECUTOR_MEMORY`
+    * @param overheadConf
+    *   Explicit overhead config entry, e.g. `EXECUTOR_MEMORY_OVERHEAD`
+    * @param overheadFactorConf
+    *   Overhead fraction config entry, used when no explicit overhead is set
+    * @param includeOffHeap
+    *   Whether to add off-heap memory, as Spark does for executors but not for drivers
+    * @return
+    *   Quantity string such as `31539Mi`, or None if the heap size is unset
+    */
+  private[submit] def derivePodMemory(
+      conf: SparkConf,
+      memoryConf: ConfigEntry[Long],
+      overheadConf: OptionalConfigEntry[Long],
+      overheadFactorConf: ConfigEntry[Double],
+      includeOffHeap: Boolean
+  ): Option[String] = {
+    if (!conf.contains(memoryConf.key)) {
+      None
+    } else {
+      val heapMiB = conf.get(memoryConf)
+      val overheadMiB = conf
+        .get(overheadConf)
+        .getOrElse {
+          math.max((conf.get(overheadFactorConf) * heapMiB).toLong, MIN_MEMORY_OVERHEAD_MIB)
+        }
+      val offHeapMiB = if (includeOffHeap) Utils.executorOffHeapMemorySizeAsMb(conf).toLong else 0L
+      Some(s"${heapMiB + overheadMiB + offHeapMiB}Mi")
+    }
   }
 
   /** Extracts additional resource types from template resources, excluding memory and CPU.

--- a/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
+++ b/src/main/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplication.scala
@@ -1589,8 +1589,8 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       "memory" -> {
         armadaJobConfig.cliConfig.driverResources.limitMemory
           .map(value => Quantity(Option(value)))
-          .orElse(templateResources.flatMap(_.limits.get("memory")))
           .orElse(derivedMemory)
+          .orElse(templateResources.flatMap(_.limits.get("memory")))
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1605,8 +1605,8 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       "memory" -> {
         armadaJobConfig.cliConfig.driverResources.requestMemory
           .map(value => Quantity(Option(value)))
-          .orElse(templateResources.flatMap(_.requests.get("memory")))
           .orElse(derivedMemory)
+          .orElse(templateResources.flatMap(_.requests.get("memory")))
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1724,8 +1724,8 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       "memory" -> {
         armadaJobConfig.cliConfig.executorResources.limitMemory
           .map(value => Quantity(Option(value)))
-          .orElse(templateResources.flatMap(_.limits.get("memory")))
           .orElse(derivedMemory)
+          .orElse(templateResources.flatMap(_.limits.get("memory")))
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {
@@ -1740,8 +1740,8 @@ private[spark] class ArmadaClientApplication extends SparkApplication {
       "memory" -> {
         armadaJobConfig.cliConfig.executorResources.requestMemory
           .map(value => Quantity(Option(value)))
-          .orElse(templateResources.flatMap(_.requests.get("memory")))
           .orElse(derivedMemory)
+          .orElse(templateResources.flatMap(_.requests.get("memory")))
           .getOrElse(Quantity(Option(DEFAULT_MEM)))
       },
       "cpu" -> {

--- a/src/test/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplicationSuite.scala
+++ b/src/test/scala/org/apache/spark/deploy/armada/submit/ArmadaClientApplicationSuite.scala
@@ -39,6 +39,14 @@ import k8s.io.api.core.v1.generated.{
 }
 import org.apache.spark.SparkConf
 import org.apache.spark.deploy.armada.Config
+import org.apache.spark.internal.config.{
+  DRIVER_MEMORY,
+  DRIVER_MEMORY_OVERHEAD,
+  DRIVER_MEMORY_OVERHEAD_FACTOR,
+  EXECUTOR_MEMORY,
+  EXECUTOR_MEMORY_OVERHEAD,
+  EXECUTOR_MEMORY_OVERHEAD_FACTOR
+}
 import org.apache.spark.deploy.k8s.submit.JavaMainAppResource
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funsuite.AnyFunSuite
@@ -2935,6 +2943,86 @@ class ArmadaClientApplicationSuite extends AnyFunSuite with BeforeAndAfter with 
     envNames should contain("SPARK_HOME")
     envNames should not contain "HADOOP_CONF_DIR"
     envNames should have size 1
+  }
+
+  private def deriveExecutorMemory(conf: SparkConf): Option[String] =
+    armadaClientApp.derivePodMemory(
+      conf,
+      EXECUTOR_MEMORY,
+      EXECUTOR_MEMORY_OVERHEAD,
+      EXECUTOR_MEMORY_OVERHEAD_FACTOR,
+      includeOffHeap = true
+    )
+
+  test("pod memory is not derived when the heap size is unset") {
+    deriveExecutorMemory(new SparkConf(false)) shouldBe None
+  }
+
+  test("pod memory is heap plus the default overhead fraction") {
+    val conf = new SparkConf(false).set("spark.executor.memory", "28g")
+    // 28g is 28672 MiB, overhead is 10% of that
+    deriveExecutorMemory(conf) shouldBe Some("31539Mi")
+  }
+
+  test("pod memory overhead honours the minimum for small heaps") {
+    val conf = new SparkConf(false).set("spark.executor.memory", "1g")
+    // 10% of 1024 MiB is below the 384 MiB floor, so the floor applies
+    deriveExecutorMemory(conf) shouldBe Some("1408Mi")
+  }
+
+  test("explicit memory overhead takes precedence over the fraction") {
+    val conf = new SparkConf(false)
+      .set("spark.executor.memory", "4g")
+      .set("spark.executor.memoryOverhead", "2g")
+    deriveExecutorMemory(conf) shouldBe Some("6144Mi")
+  }
+
+  test("memory overhead fraction is configurable") {
+    val conf = new SparkConf(false)
+      .set("spark.executor.memory", "10g")
+      .set("spark.executor.memoryOverheadFactor", "0.2")
+    deriveExecutorMemory(conf) shouldBe Some("12288Mi")
+  }
+
+  test("off-heap memory is added when enabled") {
+    val conf = new SparkConf(false)
+      .set("spark.executor.memory", "4g")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.memory.offHeap.size", "1g")
+    // 4096 heap + 409 overhead + 1024 off-heap
+    deriveExecutorMemory(conf) shouldBe Some("5529Mi")
+  }
+
+  test("off-heap memory is ignored when disabled") {
+    val conf = new SparkConf(false)
+      .set("spark.executor.memory", "4g")
+      .set("spark.memory.offHeap.size", "1g")
+    deriveExecutorMemory(conf) shouldBe Some("4505Mi")
+  }
+
+  test("driver pod memory derives from the driver heap size") {
+    val conf = new SparkConf(false).set("spark.driver.memory", "8g")
+    armadaClientApp.derivePodMemory(
+      conf,
+      DRIVER_MEMORY,
+      DRIVER_MEMORY_OVERHEAD,
+      DRIVER_MEMORY_OVERHEAD_FACTOR,
+      includeOffHeap = false
+    ) shouldBe Some("9011Mi")
+  }
+
+  test("driver pod memory ignores off-heap memory, matching Spark on Kubernetes") {
+    val conf = new SparkConf(false)
+      .set("spark.driver.memory", "4g")
+      .set("spark.memory.offHeap.enabled", "true")
+      .set("spark.memory.offHeap.size", "1g")
+    armadaClientApp.derivePodMemory(
+      conf,
+      DRIVER_MEMORY,
+      DRIVER_MEMORY_OVERHEAD,
+      DRIVER_MEMORY_OVERHEAD_FACTOR,
+      includeOffHeap = false
+    ) shouldBe Some("4505Mi")
   }
 
 }


### PR DESCRIPTION
**What:** Makes `--executor-memory`, `--executor-cores`, `--driver-memory` and `--driver-cores` take effect when the master is `armada://`.

**Why:** Every shorthand flag in `SparkSubmit` declares which cluster managers it applies to, and Armada was missing from these four. During submission the flag is checked against that list, and when the cluster manager is absent the value is skipped and never reaches the `SparkConf`. Nothing logs the skip, so the flags silently did nothing and jobs fell back to `spark-defaults.conf` or the built-in default. Reported in [gr-oss#1410](https://github.com/G-Research/gr-oss/issues/1410) after `--executor-memory 28G` was ignored and executors ran with 46G.

**Changes:**
- Adds Armada to the cluster manager list on the `executorCores`, `executorMemory`, `driverMemory` and `driverCores` option assigners
- Applies the same edit to the vendored `SparkSubmit` copies for Spark 3.3, 3.5 and 4.1
- No logic change; 12 single-token edits across 3 files

**Notes:**
- `--driver-memory` and `--driver-cores` were only affected in cluster mode, since client mode already resolves through a list that includes Armada
- `--conf` forms were never affected and continue to work, as they bypass the cluster manager check entirely
- `--num-executors`, `--files`, `--archives` and `--jars` were already correct

**How to verify:**
1. Run `mvn clean compile` and `mvn spotless:check` against the default Spark 3.5 target
2. Submit any job with `--master armada://... --executor-memory 2g`
3. Confirm the executor container reports `SPARK_EXECUTOR_MEMORY=2g` rather than the `spark-defaults.conf` value
4. Repeat in cluster mode with `--driver-memory` and confirm the driver picks it up
5. Rely on the CI matrix for the 3.3 and 4.1 copies, since `build-helper` compiles only the active version locally
